### PR TITLE
fix: Remove category field from all plugin.json files

### DIFF
--- a/plugins/sap-abap-cds/.claude-plugin/plugin.json
+++ b/plugins/sap-abap-cds/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "rest",
     "sap",
     "sap-abap-cds"
-  ],
-  "category": "abap"
+  ]
 }

--- a/plugins/sap-abap-cds/skills/sap-abap-cds/.claude-plugin/plugin.json
+++ b/plugins/sap-abap-cds/skills/sap-abap-cds/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "rest",
     "sap",
     "sap-abap-cds"
-  ],
-  "category": "abap"
+  ]
 }

--- a/plugins/sap-abap/.claude-plugin/plugin.json
+++ b/plugins/sap-abap/.claude-plugin/plugin.json
@@ -19,6 +19,5 @@
     "sap",
     "sap-abap",
     "sql"
-  ],
-  "category": "abap"
+  ]
 }

--- a/plugins/sap-abap/skills/sap-abap/.claude-plugin/plugin.json
+++ b/plugins/sap-abap/skills/sap-abap/.claude-plugin/plugin.json
@@ -19,6 +19,5 @@
     "sap",
     "sap-abap",
     "sql"
-  ],
-  "category": "abap"
+  ]
 }

--- a/plugins/sap-ai-core/.claude-plugin/plugin.json
+++ b/plugins/sap-ai-core/.claude-plugin/plugin.json
@@ -17,6 +17,5 @@
     "machine learning",
     "sap",
     "sap-ai-core"
-  ],
-  "category": "ai"
+  ]
 }

--- a/plugins/sap-ai-core/skills/sap-ai-core/.claude-plugin/plugin.json
+++ b/plugins/sap-ai-core/skills/sap-ai-core/.claude-plugin/plugin.json
@@ -17,6 +17,5 @@
     "machine learning",
     "sap",
     "sap-ai-core"
-  ],
-  "category": "ai"
+  ]
 }

--- a/plugins/sap-api-style/.claude-plugin/plugin.json
+++ b/plugins/sap-api-style/.claude-plugin/plugin.json
@@ -23,6 +23,5 @@
     "style",
     "tools",
     "xml"
-  ],
-  "category": "tooling"
+  ]
 }

--- a/plugins/sap-api-style/skills/sap-api-style/.claude-plugin/plugin.json
+++ b/plugins/sap-api-style/skills/sap-api-style/.claude-plugin/plugin.json
@@ -23,6 +23,5 @@
     "style",
     "tools",
     "xml"
-  ],
-  "category": "tooling"
+  ]
 }

--- a/plugins/sap-btp-best-practices/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-best-practices/.claude-plugin/plugin.json
@@ -20,6 +20,5 @@
     "production",
     "sap",
     "sap-btp-best-practices"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-best-practices/skills/sap-btp-best-practices/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-best-practices/skills/sap-btp-best-practices/.claude-plugin/plugin.json
@@ -20,6 +20,5 @@
     "production",
     "sap",
     "sap-btp-best-practices"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-build-work-zone-advanced/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-build-work-zone-advanced/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "sap-btp-build-work-zone-advanced",
     "work",
     "zone"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-build-work-zone-advanced/skills/sap-btp-build-work-zone-advanced/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-build-work-zone-advanced/skills/sap-btp-build-work-zone-advanced/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "sap-btp-build-work-zone-advanced",
     "work",
     "zone"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-business-application-studio/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-business-application-studio/.claude-plugin/plugin.json
@@ -27,6 +27,5 @@
     "sap",
     "sap-btp-business-application-studio",
     "studio"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-business-application-studio/skills/sap-btp-business-application-studio/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-business-application-studio/skills/sap-btp-business-application-studio/.claude-plugin/plugin.json
@@ -27,6 +27,5 @@
     "sap",
     "sap-btp-business-application-studio",
     "studio"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-cias/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cias/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "oauth",
     "sap",
     "sap-btp-cias"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-cias/skills/sap-btp-cias/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cias/skills/sap-btp-cias/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "oauth",
     "sap",
     "sap-btp-cias"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-cloud-logging/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-logging/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
     "saml",
     "sap",
     "sap-btp-cloud-logging"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-cloud-logging/skills/sap-btp-cloud-logging/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-logging/skills/sap-btp-cloud-logging/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
     "saml",
     "sap",
     "sap-btp-cloud-logging"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-cloud-platform/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-platform/.claude-plugin/plugin.json
@@ -27,6 +27,5 @@
     "sap",
     "sap-btp-cloud-platform",
     "serverless"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-cloud-platform/skills/sap-btp-cloud-platform/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-platform/skills/sap-btp-cloud-platform/.claude-plugin/plugin.json
@@ -27,6 +27,5 @@
     "sap",
     "sap-btp-cloud-platform",
     "serverless"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-cloud-transport-management/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-transport-management/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "sap",
     "sap-btp-cloud-transport-management",
     "transport"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-cloud-transport-management/skills/sap-btp-cloud-transport-management/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-transport-management/skills/sap-btp-cloud-transport-management/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "sap",
     "sap-btp-cloud-transport-management",
     "transport"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-connectivity/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-connectivity/.claude-plugin/plugin.json
@@ -20,6 +20,5 @@
     "oauth",
     "sap",
     "sap-btp-connectivity"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-connectivity/skills/sap-btp-connectivity/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-connectivity/skills/sap-btp-connectivity/.claude-plugin/plugin.json
@@ -20,6 +20,5 @@
     "oauth",
     "sap",
     "sap-btp-connectivity"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-developer-guide/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-developer-guide/.claude-plugin/plugin.json
@@ -27,6 +27,5 @@
     "rest",
     "sap",
     "sap-btp-developer-guide"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-developer-guide/skills/sap-btp-developer-guide/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-developer-guide/skills/sap-btp-developer-guide/.claude-plugin/plugin.json
@@ -27,6 +27,5 @@
     "rest",
     "sap",
     "sap-btp-developer-guide"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-integration-suite/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-integration-suite/.claude-plugin/plugin.json
@@ -23,6 +23,5 @@
     "sap",
     "sap-btp-integration-suite",
     "suite"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-integration-suite/skills/sap-btp-integration-suite/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-integration-suite/skills/sap-btp-integration-suite/.claude-plugin/plugin.json
@@ -23,6 +23,5 @@
     "sap",
     "sap-btp-integration-suite",
     "suite"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-intelligent-situation-automation/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-intelligent-situation-automation/.claude-plugin/plugin.json
@@ -19,6 +19,5 @@
     "sap",
     "sap-btp-intelligent-situation-automation",
     "situation"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-intelligent-situation-automation/skills/sap-btp-intelligent-situation-automation/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-intelligent-situation-automation/skills/sap-btp-intelligent-situation-automation/.claude-plugin/plugin.json
@@ -19,6 +19,5 @@
     "sap",
     "sap-btp-intelligent-situation-automation",
     "situation"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-job-scheduling/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-job-scheduling/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
     "sap",
     "sap-btp-job-scheduling",
     "scheduling"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-job-scheduling/skills/sap-btp-job-scheduling/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-job-scheduling/skills/sap-btp-job-scheduling/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
     "sap",
     "sap-btp-job-scheduling",
     "scheduling"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-master-data-integration/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-master-data-integration/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "oauth",
     "sap",
     "sap-btp-master-data-integration"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-master-data-integration/skills/sap-btp-master-data-integration/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-master-data-integration/skills/sap-btp-master-data-integration/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "oauth",
     "sap",
     "sap-btp-master-data-integration"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-service-manager/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-service-manager/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "sap",
     "sap-btp-service-manager",
     "service"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-btp-service-manager/skills/sap-btp-service-manager/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-service-manager/skills/sap-btp-service-manager/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "sap",
     "sap-btp-service-manager",
     "service"
-  ],
-  "category": "btp"
+  ]
 }

--- a/plugins/sap-cap-capire/.claude-plugin/plugin.json
+++ b/plugins/sap-cap-capire/.claude-plugin/plugin.json
@@ -26,6 +26,5 @@
     "sap",
     "sap-cap-capire",
     "sql"
-  ],
-  "category": "cap"
+  ]
 }

--- a/plugins/sap-cap-capire/skills/sap-cap-capire/.claude-plugin/plugin.json
+++ b/plugins/sap-cap-capire/skills/sap-cap-capire/.claude-plugin/plugin.json
@@ -27,7 +27,6 @@
     "sap-cap-capire",
     "sql"
   ],
-  "category": "cap",
   "agents": [
     "./agents/cap-cds-modeler.md",
     "./agents/cap-service-developer.md",

--- a/plugins/sap-cloud-sdk-ai/.claude-plugin/plugin.json
+++ b/plugins/sap-cloud-sdk-ai/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
     "sdk",
     "streaming",
     "typescript"
-  ],
-  "category": "ai"
+  ]
 }

--- a/plugins/sap-cloud-sdk-ai/skills/sap-cloud-sdk-ai/.claude-plugin/plugin.json
+++ b/plugins/sap-cloud-sdk-ai/skills/sap-cloud-sdk-ai/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
     "sdk",
     "streaming",
     "typescript"
-  ],
-  "category": "ai"
+  ]
 }

--- a/plugins/sap-datasphere/.claude-plugin/plugin.json
+++ b/plugins/sap-datasphere/.claude-plugin/plugin.json
@@ -30,6 +30,5 @@
     "sql",
     "tenant-integration",
     "visualization"
-  ],
-  "category": "data-analytics"
+  ]
 }

--- a/plugins/sap-datasphere/skills/sap-datasphere/.claude-plugin/plugin.json
+++ b/plugins/sap-datasphere/skills/sap-datasphere/.claude-plugin/plugin.json
@@ -24,7 +24,6 @@
     "sql",
     "visualization"
   ],
-  "category": "data-analytics",
   "agents": [
     "./agents/datasphere-integration-advisor.md",
     "./agents/datasphere-admin-helper.md",

--- a/plugins/sap-fiori-tools/.claude-plugin/plugin.json
+++ b/plugins/sap-fiori-tools/.claude-plugin/plugin.json
@@ -23,6 +23,5 @@
     "sap-fiori-tools",
     "sapui5",
     "tools"
-  ],
-  "category": "ui-development"
+  ]
 }

--- a/plugins/sap-fiori-tools/skills/sap-fiori-tools/.claude-plugin/plugin.json
+++ b/plugins/sap-fiori-tools/skills/sap-fiori-tools/.claude-plugin/plugin.json
@@ -23,6 +23,5 @@
     "sap-fiori-tools",
     "sapui5",
     "tools"
-  ],
-  "category": "ui-development"
+  ]
 }

--- a/plugins/sap-hana-cli/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-cli/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
     "sap-hana-cli",
     "sql",
     "sqlscript"
-  ],
-  "category": "hana"
+  ]
 }

--- a/plugins/sap-hana-cli/skills/sap-hana-cli/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-cli/skills/sap-hana-cli/.claude-plugin/plugin.json
@@ -21,6 +21,5 @@
     "sap-hana-cli",
     "sql",
     "sqlscript"
-  ],
-  "category": "hana"
+  ]
 }

--- a/plugins/sap-hana-cloud-data-intelligence/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-cloud-data-intelligence/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "sap-hana-cloud-data-intelligence",
     "sql",
     "sqlscript"
-  ],
-  "category": "hana"
+  ]
 }

--- a/plugins/sap-hana-cloud-data-intelligence/skills/sap-hana-cloud-data-intelligence/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-cloud-data-intelligence/skills/sap-hana-cloud-data-intelligence/.claude-plugin/plugin.json
@@ -22,6 +22,5 @@
     "sap-hana-cloud-data-intelligence",
     "sql",
     "sqlscript"
-  ],
-  "category": "hana"
+  ]
 }

--- a/plugins/sap-hana-ml/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-ml/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "sap-hana-ml",
     "sql",
     "sqlscript"
-  ],
-  "category": "hana"
+  ]
 }

--- a/plugins/sap-hana-ml/skills/sap-hana-ml/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-ml/skills/sap-hana-ml/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "sap-hana-ml",
     "sql",
     "sqlscript"
-  ],
-  "category": "hana"
+  ]
 }

--- a/plugins/sap-sac-custom-widget/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-custom-widget/.claude-plugin/plugin.json
@@ -27,6 +27,5 @@
     "widget-validate",
     "widget-generate",
     "widget-lint"
-  ],
-  "category": "data-analytics"
+  ]
 }

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/.claude-plugin/plugin.json
@@ -22,7 +22,6 @@
     "visualization",
     "widget"
   ],
-  "category": "data-analytics",
   "agents": [
     "./agents/widget-debugger.md",
     "./agents/widget-architect.md",

--- a/plugins/sap-sac-planning/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-planning/.claude-plugin/plugin.json
@@ -27,6 +27,5 @@
     "value-driver-tree",
     "version-management",
     "visualization"
-  ],
-  "category": "data-analytics"
+  ]
 }

--- a/plugins/sap-sac-planning/skills/sap-sac-planning/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-planning/skills/sap-sac-planning/.claude-plugin/plugin.json
@@ -21,7 +21,6 @@
     "sap-sac-planning",
     "visualization"
   ],
-  "category": "data-analytics",
   "agents": [
     "./agents/planning-api-assistant.md",
     "./agents/data-action-debugger.md",

--- a/plugins/sap-sac-scripting/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-scripting/.claude-plugin/plugin.json
@@ -33,6 +33,5 @@
     "timer",
     "data-actions",
     "version-management"
-  ],
-  "category": "data-analytics"
+  ]
 }

--- a/plugins/sap-sac-scripting/skills/sap-sac-scripting/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-scripting/skills/sap-sac-scripting/.claude-plugin/plugin.json
@@ -19,7 +19,6 @@
     "scripting",
     "visualization"
   ],
-  "category": "data-analytics",
   "agents": [
     "./agents/sac-api-helper.md",
     "./agents/sac-planning-assistant.md",

--- a/plugins/sap-sqlscript/.claude-plugin/plugin.json
+++ b/plugins/sap-sqlscript/.claude-plugin/plugin.json
@@ -20,6 +20,5 @@
     "sql",
     "sqlscript",
     "tools"
-  ],
-  "category": "tooling"
+  ]
 }

--- a/plugins/sap-sqlscript/skills/sap-sqlscript/.claude-plugin/plugin.json
+++ b/plugins/sap-sqlscript/skills/sap-sqlscript/.claude-plugin/plugin.json
@@ -21,7 +21,6 @@
     "sqlscript",
     "visualization"
   ],
-  "category": "data-analytics",
   "agents": [
     "./agents/amdp-helper.md",
     "./agents/procedure-generator.md",

--- a/plugins/sapui5-cli/.claude-plugin/plugin.json
+++ b/plugins/sapui5-cli/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "sapui5",
     "sapui5-cli",
     "yaml"
-  ],
-  "category": "ui-development"
+  ]
 }

--- a/plugins/sapui5-cli/skills/sapui5-cli/.claude-plugin/plugin.json
+++ b/plugins/sapui5-cli/skills/sapui5-cli/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "sapui5",
     "sapui5-cli",
     "yaml"
-  ],
-  "category": "ui-development"
+  ]
 }

--- a/plugins/sapui5-linter/.claude-plugin/plugin.json
+++ b/plugins/sapui5-linter/.claude-plugin/plugin.json
@@ -25,6 +25,5 @@
     "typescript",
     "xml",
     "yaml"
-  ],
-  "category": "ui-development"
+  ]
 }

--- a/plugins/sapui5-linter/skills/sapui5-linter/.claude-plugin/plugin.json
+++ b/plugins/sapui5-linter/skills/sapui5-linter/.claude-plugin/plugin.json
@@ -25,6 +25,5 @@
     "typescript",
     "xml",
     "yaml"
-  ],
-  "category": "ui-development"
+  ]
 }

--- a/plugins/sapui5/.claude-plugin/plugin.json
+++ b/plugins/sapui5/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "sapui5",
     "typescript",
     "xml"
-  ],
-  "category": "ui-development"
+  ]
 }

--- a/plugins/sapui5/skills/sapui5/.claude-plugin/plugin.json
+++ b/plugins/sapui5/skills/sapui5/.claude-plugin/plugin.json
@@ -19,7 +19,6 @@
     "typescript",
     "xml"
   ],
-  "category": "ui-development",
   "agents": [
     "./agents/ui5-migration-specialist.md",
     "./agents/ui5-api-explorer.md",

--- a/plugins/skill-review/.claude-plugin/plugin.json
+++ b/plugins/skill-review/.claude-plugin/plugin.json
@@ -20,6 +20,5 @@
     "skill-review",
     "tools",
     "yaml"
-  ],
-  "category": "tooling"
+  ]
 }

--- a/plugins/skill-review/skills/skill-review/.claude-plugin/plugin.json
+++ b/plugins/skill-review/skills/skill-review/.claude-plugin/plugin.json
@@ -20,6 +20,5 @@
     "skill-review",
     "tools",
     "yaml"
-  ],
-  "category": "tooling"
+  ]
 }


### PR DESCRIPTION
## Summary
Removed the "category" field from all 66 plugin.json manifests across 33 plugins. The category field is only allowed in marketplace.json, not in individual plugin manifests according to Claude Code plugin standards.

## Changes
- Removed category field from 33 top-level plugin.json files (`plugins/*/.claude-plugin/plugin.json`)
- Removed category field from 33 skill-level plugin.json files (`plugins/*/skills/*/.claude-plugin/plugin.json`)
- Verified marketplace.json still contains category information (unchanged)
- Maintained JSON formatting and structure (2-space indentation)

## Verification
- ✅ No "category" fields remain in any plugin.json files
- ✅ marketplace.json still contains 33 category fields
- ✅ All JSON files remain valid

## Files Modified
66 files changed: 59 insertions(+), 125 deletions(-)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin manifest configurations to streamline metadata structure by removing deprecated fields from multiple plugin definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->