### PR TITLE
fix: Remove Markdown link syntax from YAML frontmatter

### DIFF
--- a/plugins/sap-abap-cds/skills/sap-abap-cds/SKILL.md
+++ b/plugins/sap-abap-cds/skills/sap-abap-cds/SKILL.md
@@ -10,8 +10,8 @@ metadata:
   last_verified: "2025-11-23"
   abap_release: "7.4 SP8+ / ABAP Cloud"
   sources:
-    - "[https://help.sap.com/doc/abapdocu_cp_index_htm/CLOUD/en-US/abencds.html"](https://help.sap.com/doc/abapdocu_cp_index_htm/CLOUD/en-US/abencds.html")
-    - "[https://github.com/SAP-samples/abap-cheat-sheets"](https://github.com/SAP-samples/abap-cheat-sheets")
+    - "https://help.sap.com/doc/abapdocu_cp_index_htm/CLOUD/en-US/abencds.html"
+    - "https://github.com/SAP-samples/abap-cheat-sheets"
 ---
 
 # SAP ABAP CDS (Core Data Services)

--- a/plugins/sap-btp-cias/skills/sap-btp-cias/SKILL.md
+++ b/plugins/sap-btp-cias/skills/sap-btp-cias/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   version: "1.0.1"
   last_verified: "2025-11-27"
   sap_product: "Cloud Integration Automation Service"
-  source_docs: "[https://github.com/SAP-docs/btp-cloud-integration-automation-service"](https://github.com/SAP-docs/btp-cloud-integration-automation-service")
+  source_docs: "https://github.com/SAP-docs/btp-cloud-integration-automation-service"
 ---
 
 # SAP BTP Cloud Integration Automation Service (CIAS)

--- a/plugins/sap-btp-cloud-logging/skills/sap-btp-cloud-logging/SKILL.md
+++ b/plugins/sap-btp-cloud-logging/skills/sap-btp-cloud-logging/SKILL.md
@@ -12,8 +12,8 @@ license: GPL-3.0
 metadata:
   version: "1.1.0"
   last_verified: "2025-11-27"
-  source_documentation: "[https://github.com/SAP-docs/btp-cloud-logging"](https://github.com/SAP-docs/btp-cloud-logging")
-  sap_help_portal: "[https://help.sap.com/docs/cloud-logging"](https://help.sap.com/docs/cloud-logging")
+  source_documentation: "https://github.com/SAP-docs/btp-cloud-logging"
+  sap_help_portal: "https://help.sap.com/docs/cloud-logging"
 ---
 
 # SAP BTP Cloud Logging Skill

--- a/plugins/sap-btp-cloud-transport-management/skills/sap-btp-cloud-transport-management/SKILL.md
+++ b/plugins/sap-btp-cloud-transport-management/skills/sap-btp-cloud-transport-management/SKILL.md
@@ -6,7 +6,7 @@ license: GPL-3.0
 metadata:
   version: "1.0.0"
   last_verified: "2025-11-27"
-  sap_documentation_source: "[https://help.sap.com/docs/cloud-transport-management"](https://help.sap.com/docs/cloud-transport-management")
+  sap_documentation_source: "https://help.sap.com/docs/cloud-transport-management"
 ---
 
 # SAP Cloud Transport Management Skill

--- a/plugins/sap-btp-service-manager/skills/sap-btp-service-manager/SKILL.md
+++ b/plugins/sap-btp-service-manager/skills/sap-btp-service-manager/SKILL.md
@@ -8,7 +8,7 @@ license: GPL-3.0
 metadata:
   version: 1.1.1
   last_verified: 2025-11-27
-  documentation_source: [https://github.com/SAP-docs/sap-btp-service-manager](https://github.com/SAP-docs/sap-btp-service-manager)
+  documentation_source: "https://github.com/SAP-docs/sap-btp-service-manager"
   documentation_files_analyzed: 80+
   reference_files: 6
   template_files: 5

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
@@ -12,9 +12,9 @@ metadata:
   sac_version: "2025.21"
   errors_prevented: 25+
   official_docs:
-    - [https://help.sap.com/docs/SAP_ANALYTICS_CLOUD/0ac8c6754ff84605a4372468d002f2bf/75311f67527c41638ceb89af9cd8af3e.html](https://help.sap.com/docs/SAP_ANALYTICS_CLOUD/0ac8c6754ff84605a4372468d002f2bf/75311f67527c41638ceb89af9cd8af3e.html)
-    - [https://help.sap.com/doc/c813a28922b54e50bd2a307b099787dc/release/en-US/CustomWidgetDevGuide_en.pdf](https://help.sap.com/doc/c813a28922b54e50bd2a307b099787dc/release/en-US/CustomWidgetDevGuide_en.pdf)
-  samples_repo: [https://github.com/SAP-samples/analytics-cloud-datasphere-community-content/tree/main/SAC_Custom_Widgets](https://github.com/SAP-samples/analytics-cloud-datasphere-community-content/tree/main/SAC_Custom_Widgets)
+    - "https://help.sap.com/docs/SAP_ANALYTICS_CLOUD/0ac8c6754ff84605a4372468d002f2bf/75311f67527c41638ceb89af9cd8af3e.html"
+    - "https://help.sap.com/doc/c813a28922b54e50bd2a307b099787dc/release/en-US/CustomWidgetDevGuide_en.pdf"
+  samples_repo: "https://github.com/SAP-samples/analytics-cloud-datasphere-community-content/tree/main/SAC_Custom_Widgets"
 allowed-tools:
   - Read
   - Write

--- a/plugins/sap-sac-planning/skills/sap-sac-planning/SKILL.md
+++ b/plugins/sap-sac-planning/skills/sap-sac-planning/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   version: 1.4.0
   last_verified: 2025-12-27
   sac_version: "2025.25"
-  documentation_source: [https://help.sap.com/docs/SAP_ANALYTICS_CLOUD/00f68c2e08b941f081002fd3691d86a7](https://help.sap.com/docs/SAP_ANALYTICS_CLOUD/00f68c2e08b941f081002fd3691d86a7)
-  api_reference: [https://help.sap.com/doc/958d4c11261f42e992e8d01a4c0dde25/2025.25/en-US/index.html](https://help.sap.com/doc/958d4c11261f42e992e8d01a4c0dde25/2025.25/en-US/index.html)
+  documentation_source: "https://help.sap.com/docs/SAP_ANALYTICS_CLOUD/00f68c2e08b941f081002fd3691d86a7"
+  api_reference: "https://help.sap.com/doc/958d4c11261f42e992e8d01a4c0dde25/2025.25/en-US/index.html"
   reference_files: 24
   status: production
 ---

--- a/plugins/sapui5-cli/skills/sapui5-cli/SKILL.md
+++ b/plugins/sapui5-cli/skills/sapui5-cli/SKILL.md
@@ -5,7 +5,7 @@ license: GPL-3.0
 metadata:
   version: 4.0.0
   lastUpdated: 2025-11-21
-  officialDocs: [https://ui5.github.io/cli/stable/](https://ui5.github.io/cli/stable/)
+  officialDocs: "https://ui5.github.io/cli/stable/"
 ---
 
 # SAPUI5/OpenUI5 CLI Management Skill

--- a/plugins/sapui5-linter/skills/sapui5-linter/SKILL.md
+++ b/plugins/sapui5-linter/skills/sapui5-linter/SKILL.md
@@ -10,8 +10,8 @@ metadata:
   version: "1.0.0"
   last_updated: "2025-11-26"
   ui5_linter_version: "1.20.5
-  source: [https://github.com/UI5/linter](https://github.com/UI5/linter)
-  documentation: [https://github.com/UI5/linter/blob/main/README.md](https://github.com/UI5/linter/blob/main/README.md)
+  source: "https://github.com/UI5/linter"
+  documentation: "https://github.com/UI5/linter/blob/main/README.md"
   status: "CONTENT_RESTRUCTURED"
 ---
 


### PR DESCRIPTION
## Summary
Fixes YAML parsing errors in 9 SKILL.md files by removing Markdown link syntax from metadata fields.

## Problem
YAML parsers interpret brackets `[]` and parentheses `()` as structural elements, causing parsing failures that prevent skills from being installed via `npx skills add`.

## Solution
Replaced Markdown link syntax `[url](url)` with plain quoted URLs `"url"` in YAML frontmatter metadata blocks.

## Files Changed
- plugins/sap-abap-cds/skills/sap-abap-cds/SKILL.md
- plugins/sapui5-cli/skills/sapui5-cli/SKILL.md
- plugins/sapui5-linter/skills/sapui5-linter/SKILL.md
- plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
- plugins/sap-sac-planning/skills/sap-sac-planning/SKILL.md
- plugins/sap-btp-cias/skills/sap-btp-cias/SKILL.md
- plugins/sap-btp-cloud-logging/skills/sap-btp-cloud-logging/SKILL.md
- plugins/sap-btp-cloud-transport-management/skills/sap-btp-cloud-transport-management/SKILL.md
- plugins/sap-btp-service-manager/skills/sap-btp-service-manager/SKILL.md

## Testing
- [x] All YAML frontmatter now uses plain quoted URLs
- [x] No Markdown link syntax remains in metadata blocks
- [x] Commit includes proper issue reference

Resolves #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected malformed documentation URLs and YAML metadata formatting across multiple SAP plugin skill definitions by converting improperly formatted links to standardized plain URL strings.
  * Fixed metadata string formatting issues including missing quote termination and extraneous markdown link syntax for improved documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->