### PR TITLE
fix: replace dispatch.sh with direct node command for Windows compatibility

### DIFF
--- a/plugins/sap-cap-capire/hooks/hooks.json
+++ b/plugins/sap-cap-capire/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 30
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 15
           }
         ]

--- a/plugins/sap-datasphere/hooks/hooks.json
+++ b/plugins/sap-datasphere/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 30
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 15
           }
         ]

--- a/plugins/sap-sac-custom-widget/hooks/hooks.json
+++ b/plugins/sap-sac-custom-widget/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 45
           }
         ]

--- a/plugins/sap-sac-planning/hooks/hooks.json
+++ b/plugins/sap-sac-planning/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 30
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 15
           }
         ]

--- a/plugins/sap-sac-scripting/hooks/hooks.json
+++ b/plugins/sap-sac-scripting/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 30
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 15
           }
         ]

--- a/plugins/sap-sqlscript/hooks/hooks.json
+++ b/plugins/sap-sqlscript/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 45
           }
         ]

--- a/plugins/sapui5/hooks/hooks.json
+++ b/plugins/sapui5/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 30
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 15
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/dispatch.sh",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs\"",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
## Summary

- On Windows, `child_process.spawn()` without `shell: true` cannot execute `.sh` scripts, so `./hooks/dispatch.sh` fails with `ENOENT`
- `dispatch.sh` is a runtime detector that tries node, then falls back to python3/python/py
- Since Claude Code requires Node.js, node is always available -- the Python fallback is unnecessary
- Replace `./hooks/dispatch.sh` with `node "${CLAUDE_PLUGIN_ROOT}/hooks/validator.mjs"` in all 7 affected plugins

This calls the same `validator.mjs` that `dispatch.sh` was calling, just without the bash wrapper. Works on all platforms -- Mac and Linux are unaffected since `node` is in PATH there too.

## Affected plugins

- sap-cap-capire (2 hooks)
- sap-datasphere (2 hooks)
- sap-sac-custom-widget (1 hook)
- sap-sac-planning (2 hooks)
- sap-sac-scripting (2 hooks)
- sap-sqlscript (1 hook)
- sapui5 (3 hooks)

## Related issues

- anthropics/claude-code#19658 -- Windows spawn ENOENT for npm global binaries
- anthropics/claude-code#27061 -- LSP/hook plugins fail with spawn ENOENT on Windows

## Test plan

- [x] Tested on Windows 11 with Claude Code -- all 7 plugin hooks execute successfully after fix
- [ ] Verify no regression on Mac/Linux (node is in PATH, `${CLAUDE_PLUGIN_ROOT}` resolves correctly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved validation infrastructure across multiple SAP plugins (CAP CAPIRE, Datasphere, SAC Custom Widget, SAC Planning, SAC Scripting, SQLScript, SAPUI5). All existing timeouts and configurations are preserved with no changes to current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->