### PR TITLE
fix(sapui5): remove broken ${cwd} and unused env vars from .mcp.json

### DIFF
--- a/plugins/sapui5/.mcp.json
+++ b/plugins/sapui5/.mcp.json
@@ -3,8 +3,6 @@
     "command": "npx",
     "args": ["-y", "@ui5/mcp-server"],
     "env": {
-      "UI5_PROJECT_DIR": "${cwd}",
-      "UI5_VERSION": "1.120.0",
       "UI5_MCP_SERVER_RESPONSE_NO_RESOURCES": "true"
     }
   }

--- a/plugins/sapui5/skills/sapui5/references/mcp-integration.md
+++ b/plugins/sapui5/skills/sapui5/references/mcp-integration.md
@@ -99,24 +99,43 @@ The sapui5 plugin includes `.mcp.json` at the plugin root:
     "command": "npx",
     "args": ["-y", "@ui5/mcp-server"],
     "env": {
-      "UI5_PROJECT_DIR": "${cwd}",
-      "UI5_VERSION": "1.120.0",
       "UI5_MCP_SERVER_RESPONSE_NO_RESOURCES": "true"
     }
   }
 }
 ```
 
+### Cross-Platform Note
+
+The MCP config uses `npx` directly, which works on macOS and Linux. On **native Windows** (non-WSL), `npx` may fail to spawn because it is a `.cmd` batch file. If the MCP server fails to start on Windows, manually override `.mcp.json` to use `cmd /c npx`:
+
+```json
+{
+  "ui5-tooling": {
+    "command": "cmd",
+    "args": ["/c", "npx", "-y", "@ui5/mcp-server"],
+    "env": {
+      "UI5_MCP_SERVER_RESPONSE_NO_RESOURCES": "true"
+    }
+  }
+}
+```
+
+This decision trades automatic Windows compatibility for a config that works correctly on macOS and Linux without platform-specific branching (`.mcp.json` does not support platform conditionals).
+
 ### Environment Variables
+
+The `@ui5/mcp-server` recognizes the following environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `UI5_PROJECT_DIR` | `${cwd}` | Project root directory for context-aware operations |
-| `UI5_VERSION` | `1.120.0` | Default UI5 version for API lookups |
-| `UI5_MCP_SERVER_RESPONSE_NO_RESOURCES` | `true` | Disable resources for client compatibility |
-| `UI5_MCP_SERVER_ALLOWED_ODATA_DOMAINS` | `localhost, services.odata.org` | Comma-separated list of allowed OData domains |
+| `UI5_MCP_SERVER_RESPONSE_NO_RESOURCES` | — | Disable resources for client compatibility |
+| `UI5_MCP_SERVER_ALLOWED_DOMAINS` | — | Comma-separated list of allowed domains |
+| `UI5_MCP_SERVER_CDN_URL` | — | Custom CDN URL for UI5 resources |
 | `UI5_LOG_LVL` | `info` | Log level: silent, error, warn, info, perf, verbose, silly |
 | `UI5_DATA_DIR` | `~/.ui5` | Directory for cached data (API references) |
+
+Project discovery happens via a `path` parameter on each tool call (e.g., `get_project_info`), not via an environment variable. UI5 version is detected automatically from the project's `manifest.json`.
 
 ### User Settings Integration
 
@@ -589,11 +608,11 @@ If specific tools fail but MCP server is running:
 
 ### Issue: MCP tools return wrong version information
 
-**Cause**: Environment variable `UI5_VERSION` not set correctly
+**Cause**: UI5 version not detected correctly from the project
 
 **Solution**:
-1. Check `.mcp.json` configuration
-2. Verify project manifest.json has correct `minUI5Version`
+1. Verify project `manifest.json` has correct `minUI5Version`
+2. Pass the `path` parameter to MCP tools to ensure correct project context
 3. Override in `sapui5.local.md`:
 
 ```yaml


### PR DESCRIPTION
## Summary

- Removes `${cwd}` from `plugins/sapui5/.mcp.json` — this is **not** a supported Claude Code variable and caused the plugin to fail loading entirely with `Missing environment variables: cwd`
- Removes `UI5_PROJECT_DIR` and `UI5_VERSION` env vars — they are **not read** by `@ui5/mcp-server` (project discovery happens via `path` parameter on each tool call, UI5 version is auto-detected from `manifest.json`)
- Updates `mcp-integration.md` reference to document correct env vars and adds a **Cross-Platform Note** explaining the `npx`-on-Windows limitation and `cmd /c npx` workaround

Closes #72

## Files Changed

- `plugins/sapui5/.mcp.json` — Removed 3 broken/unused env entries
- `plugins/sapui5/skills/sapui5/references/mcp-integration.md` — Updated config docs, env var table, cross-platform note, troubleshooting section

## Cross-Platform Decision

The config uses `npx` directly (works on macOS/Linux). On **native Windows** (non-WSL), `npx` may fail to spawn. Rather than wrapping with `cmd /c` (which breaks macOS/Linux), the decision is to document the workaround for Windows users to manually override. `.mcp.json` does not support platform conditionals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified configuration with automatic project discovery and UI5 version detection
  * Updated environment variable naming and introduced new CDN URL configuration option
  * Added Windows cross-platform troubleshooting guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->