### PR TITLE
[codex] Release 2.3.1 docs and marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "name": "sap-skills",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "SAP development skills with evidence-tracked public-source and package-registry verification",
   "repository": "https://github.com/secondsky/sap-skills",
   "owner": {
     "name": "E.J."
   },
   "metadata": {
-    "version": "2.3.0",
+    "version": "2.3.1",
     "last_updated": "2026-06-19",
     "total_skills": 37,
     "categories": [
@@ -26,7 +26,7 @@
       "name": "sap-abap",
       "source": "./plugins/sap-abap",
       "description": "Comprehensive ABAP development skill for SAP systems. Use when writing ABAP code, working with internal tables, structures, ABAP SQL, object-oriented programming, RAP (RESTful Application Programming Model), CDS views, EML statements, ABAP Cloud development, string processing, dynamic programming, RTTI/RTTC, field symbols, data references, exception handling, or ABAP unit testing. Covers both classic ABAP and modern ABAP for Cloud Development patterns.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "abap",
       "keywords": [
         "abap",
@@ -49,7 +49,7 @@
       "name": "sap-abap-cds",
       "source": "./plugins/sap-abap-cds",
       "description": "Comprehensive SAP ABAP CDS (Core Data Services) reference for data modeling, view development, and semantic enrichment. Use when creating CDS views or view entities, defining data models with annotations, working with associations and cardinality, implementing input parameters, using built-in functions, writing CASE expressions, implementing access control with DCL, handling CURR/QUAN data types, troubleshooting CDS errors, querying CDS views from ABAP, or displaying data with SALV IDA. Covers ABAP 7.4+ through ABAP Cloud.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "abap",
       "keywords": [
         "abap",
@@ -70,7 +70,7 @@
       "name": "sap-ai-core",
       "source": "./plugins/sap-ai-core",
       "description": "Guides development with SAP AI Core and SAP AI Launchpad for enterprise AI/ML workloads on SAP BTP. Use when: deploying generative AI models, building orchestration workflows with templating/filtering/grounding, implementing RAG with vector databases, managing ML training pipelines with Argo Workflows, configuring content filtering and data masking for PII protection, using the Generative AI Hub for prompt experimentation, managing prompt templates via the Prompt Registry, or integrating AI capabilities into SAP applications. Covers service plans (Free/Standard/Extended), model providers (Azure OpenAI, AWS Bedrock, GCP Vertex AI, Mistral, IBM, Perplexity), orchestration modules, embeddings, tool calling, and structured outputs.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "ai",
       "keywords": [
         "artificial intelligence",
@@ -91,7 +91,7 @@
       "name": "sap-api-style",
       "source": "./plugins/sap-api-style",
       "description": "This skill provides comprehensive guidance for documenting SAP APIs following the SAP API Style Guide standards. It should be used when creating or reviewing API documentation for REST, OData, Java, JavaScript, .NET, or C/C++ APIs. The skill covers naming conventions, documentation comments, OpenAPI specifications, quality checklists, deprecation policies, and manual documentation templates. It ensures consistency with SAP API Business Hub standards and industry best practices. Keywords: SAP API, REST, OData, OpenAPI, Swagger, Javadoc, JSDoc, XML documentation, API Business Hub, API naming, API deprecation, x-sap-stateInfo, Entity Data Model, EDM, documentation tags, API quality, API templates",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "tooling",
       "keywords": [
         "api",
@@ -121,7 +121,7 @@
       "name": "sap-btp-best-practices",
       "source": "./plugins/sap-btp-best-practices",
       "description": "SAP BTP best practices for enterprise architecture, account management, security, and operations, with verification evidence tracked in the repository ledger. Use when planning BTP implementations, setting up account hierarchies, configuring environments, implementing authentication, designing CI/CD pipelines, establishing governance, building Platform Engineering teams, implementing failover strategies, or managing application lifecycle on SAP BTP. Keywords: SAP BTP, account hierarchy, global account, directory, subaccount, Cloud Foundry, Kyma, ABAP, SAP Identity Authentication, CI/CD, governance, Platform Engineering, failover, multi-region, SAP BTP best practices",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "abap",
@@ -145,7 +145,7 @@
       "name": "sap-btp-build-work-zone-advanced",
       "source": "./plugins/sap-btp-build-work-zone-advanced",
       "description": "Develops and administers SAP Build Work Zone, advanced edition digital workplace solutions. Use when creating workspaces, workpages, and collaborative sites, developing UI Integration Cards in SAP Business Application Studio, building content packages and workspace templates, integrating with Microsoft 365/Teams/SharePoint/Google Drive, configuring chatbots and webhooks, implementing SCIM API user provisioning, setting up OData business records, managing themes and branding, configuring role-based access and SSO, troubleshooting deployment issues, or working with the Administration Console. Keywords: SAP Build Work Zone advanced edition, digital workplace, UI Integration Cards, content packages, workspace templates, SAP Business Application Studio, SAP Conversational AI, SCIM API, OData, Microsoft Teams integration, SSO, theming, Administration Console",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "advanced",
@@ -171,7 +171,7 @@
       "name": "sap-btp-business-application-studio",
       "source": "./plugins/sap-btp-business-application-studio",
       "description": "This skill provides comprehensive guidance for SAP Business Application Studio (BAS), the cloud-based IDE on SAP BTP built on Code-OSS. Use when setting up BAS subscriptions, creating dev spaces, connecting to external systems, deploying MTA applications, troubleshooting connectivity issues, managing Git repositories, configuring runtime versions, or using the layout editor. Keywords: SAP Business Application Studio, BAS, SAP BTP, dev space, Cloud Foundry, MTA, multitarget application, SAP Fiori, CAP, HANA, destination, WebIDEEnabled, Cloud Connector, Service Center, Storyboard, Layout Editor, ABAP, OData, subscription, entitlements, role collection, Business_Application_Studio_Developer, Git, clone, push, pull, Gerrit, PAT, OAuth, asdf, runtime, Node.js, Java, Python, Task Explorer, CI/CD, Yeoman, generator, template wizard, mbt, mtar, debugging, breakpoint",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "abap",
@@ -202,7 +202,7 @@
       "name": "sap-btp-cias",
       "source": "./plugins/sap-btp-cias",
       "description": "SAP BTP Cloud Integration Automation Service (CIAS) skill for guided integration workflows. Use when: setting up CIAS subscriptions, configuring destinations, assigning roles (CIASIntegrationAdministrator, CIASIntegrationExpert, CIASIntegrationMonitor), planning integration scenarios, working with My Inbox tasks, monitoring scenario execution, troubleshooting CIAS errors, creating OAuth2 instances, configuring identity providers for CIAS, understanding CIAS security architecture, or integrating SAP products (S/4HANA, SuccessFactors, BTP services, SAP Build, IBP).",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "btp",
@@ -224,7 +224,7 @@
       "name": "sap-btp-cloud-identity-services",
       "source": "./plugins/sap-btp-cloud-identity-services",
       "description": "SAP Cloud Identity Services for BTP applications: Identity Authentication (IAS), Identity Provisioning (IPS), and Authorization Management (AMS). Use when configuring authentication for BTP apps, setting up OIDC or SAML app registrations, federating corporate identity providers, establishing subaccount trust, provisioning users, writing AMS authorization policies, migrating from XSUAA to IAS-based authentication, or troubleshooting token and trust errors.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "authentication",
@@ -252,7 +252,7 @@
       "name": "sap-btp-cloud-logging",
       "source": "./plugins/sap-btp-cloud-logging",
       "description": "This skill provides comprehensive guidance for SAP Cloud Logging service on SAP BTP. Use when setting up Cloud Logging instances, configuring log ingestion from Cloud Foundry or Kyma runtimes, implementing OpenTelemetry observability, analyzing logs/metrics/traces in OpenSearch Dashboards, configuring SAML authentication, managing certificates, or troubleshooting ingestion issues. Covers service plans (dev/standard/large), all 4 instance creation methods (BTP Cockpit, CF CLI, BTP CLI, Service Operator), all 4 ingestion methods (Cloud Foundry, Kyma, OpenTelemetry, JSON API), and security best practices.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "api",
@@ -277,7 +277,7 @@
       "name": "sap-btp-cloud-platform",
       "source": "./plugins/sap-btp-cloud-platform",
       "description": "Comprehensive SAP Business Technology Platform (BTP) reference for cloud development, deployment, and operations. Use when setting up BTP accounts, working with Cloud Foundry environment, deploying to Kyma (Kubernetes, serverless), developing in ABAP environment (RAP, CDS), managing entitlements and quotas, configuring identity providers (XSUAA), using btp CLI or CF CLI, deploying multi-target applications (MTA), setting up connectivity (destinations, Cloud Connector), implementing CI/CD pipelines, extending SAP solutions, or troubleshooting BTP services. Covers all three runtime environments.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "abap",
@@ -305,7 +305,7 @@
       "name": "sap-btp-cloud-transport-management",
       "source": "./plugins/sap-btp-cloud-transport-management",
       "description": "Comprehensive skill for SAP Cloud Transport Management service on SAP BTP. Use when setting up transport landscapes, configuring transport nodes and routes, managing import queues, deploying MTAs across Cloud Foundry environments, integrating with CI/CD pipelines, configuring ABAP environment transports, troubleshooting deployment errors, or implementing change management workflows. Covers entitlements, subscriptions, role collections, service instances, destinations, and API integrations.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "abap",
@@ -331,7 +331,7 @@
       "name": "sap-btp-connectivity",
       "source": "./plugins/sap-btp-connectivity",
       "description": "SAP BTP Connectivity skill covering Destination Service, Connectivity Service, Cloud Connector, Connectivity Proxy, and Transparent Proxy for Kubernetes. Use when configuring destinations (HTTP, RFC, LDAP, MAIL, TCP), setting up cloud-to-on-premise connectivity, implementing OAuth and principal propagation, deploying connectivity proxies in Kubernetes/Kyma, troubleshooting connectivity errors (405, 407, 503), or configuring multitenancy.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "btp",
@@ -353,7 +353,7 @@
       "name": "sap-btp-developer-guide",
       "source": "./plugins/sap-btp-developer-guide",
       "description": "Develops business applications on SAP Business Technology Platform (BTP) using CAP (Node.js/Java) or ABAP Cloud.  Use when: building cloud applications on SAP BTP, deploying to Cloud Foundry or Kyma runtimes, integrating with SAP HANA Cloud, implementing SAP Fiori UIs, connecting to remote SAP systems, building multitenant SaaS applications, extending SAP S/4HANA or SuccessFactors, setting up CI/CD pipelines, implementing observability, or following SAP development best practices. Keywords: SAP BTP, Business Technology Platform, CAP, Cloud Application Programming Model, ABAP Cloud, Cloud Foundry, Kyma, SAP HANA Cloud, SAP Fiori, SAPUI5, CI/CD, observability, multitenant, SaaS, SAP BTP ABAP environment, SAP Business Application Studio, SAP Cloud SDK, SAP Integration Suite, SAP Event Mesh, SAP Connectivity Service, SAP Destination Service, XSUAA, OAuth, OpenID Connect, OData, CDS, Core Data Services, ABAP CDS, ABAP RESTful Application Programming Model, RAP, ABAP development, SAP BTP development",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "abap",
@@ -384,7 +384,7 @@
       "name": "sap-btp-integration-suite",
       "source": "./plugins/sap-btp-integration-suite",
       "description": "Enterprise integration solutions using SAP Integration Suite on BTP. Covers Cloud Integration (iFlows), API Management, Event Mesh, Edge Integration Cell, Integration Advisor, Trading Partner Management, and Migration Assessment. Use for building integration flows, managing API proxies, event-driven architectures, B2B/EDI integrations, hybrid deployments, adapter configuration, Groovy/JavaScript message processing, and troubleshooting.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "api",
@@ -413,7 +413,7 @@
       "name": "sap-btp-intelligent-situation-automation",
       "source": "./plugins/sap-btp-intelligent-situation-automation",
       "description": "This archived skill provides legacy guidance for SAP BTP Intelligent Situation Automation data export, unsubscription, and configuration review. It should be used only when maintaining existing ISA tenants, exporting data before access is removed, or understanding historical situation automation setups. The skill covers Event Mesh integration, destination configuration, system onboarding, user management with role collections, automatic situation resolution, unsubscription, and troubleshooting for existing deployments. Keywords: SAP BTP, Intelligent Situation Automation, ISA, situation handling, SAP S/4HANA, SAP S/4HANA Cloud, Event Mesh, Business Event Handling, situation automation, situation dashboard, analyze situations, SAP_COM_0345, SAP_COM_0376, SAP_COM_0092, SituationAutomationKeyUser, SituationAutomationAdminUser, Cloud Connector, cf-eu10, CA-SIT-ATM, business situations, situation types, situation actions",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "automation",
@@ -437,7 +437,7 @@
       "name": "sap-btp-job-scheduling",
       "source": "./plugins/sap-btp-job-scheduling",
       "description": "This skill provides comprehensive guidance for SAP BTP Job Scheduling Service development, configuration, and operations. It should be used when creating, managing, or troubleshooting scheduled jobs on SAP Business Technology Platform. The skill covers service setup, REST API usage, schedule types and formats, OAuth 2.0 authentication, multitenancy, Cloud Foundry tasks, Kyma runtime integration, and monitoring with SAP Cloud ALM and Alert Notification Service. Keywords: SAP BTP, Job Scheduling, jobscheduler, cron, schedule, recurring jobs, one-time jobs, Cloud Foundry tasks, CF tasks, Kyma, OAuth 2.0, XSUAA, @sap/jobs-client, REST API, asynchronous jobs, action endpoint, run logs, SAP Cloud ALM, Alert Notification Service, multitenancy, tenant-aware, BC-CP-CF-JBS",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "api",
@@ -462,7 +462,7 @@
       "name": "sap-btp-master-data-integration",
       "source": "./plugins/sap-btp-master-data-integration",
       "description": "Configures and integrates SAP Master Data Integration (MDI) service on SAP Business Technology Platform. Use when setting up MDI tenants, connecting applications (S/4HANA, SuccessFactors, Ariba, Fieldglass, etc.), configuring distribution models, SOAP APIs for business partners, extensibility, or troubleshooting master data replication. Covers One Domain Model integration, Business Data Orchestration, client authentication (OAuth2, mTLS), and security configurations.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "api",
@@ -488,7 +488,7 @@
       "name": "sap-btp-service-manager",
       "source": "./plugins/sap-btp-service-manager",
       "description": "This skill provides comprehensive knowledge for SAP Service Manager on SAP Business Technology Platform (BTP). It should be used when managing service instances, bindings, brokers, and platforms across Cloud Foundry, Kyma, Kubernetes, and other environments. Use when provisioning services via SMCTL CLI, BTP CLI, or REST APIs, configuring OAuth2 authentication, working with the SAP BTP Service Operator in Kubernetes, troubleshooting service consumption issues, or implementing cross-environment service management. Keywords: SAP Service Manager, BTP, service instances, service bindings, SMCTL, service broker, OSBAPI, Cloud Foundry, Kyma, Kubernetes, service-manager, service-operator-access, subaccount-admin, OAuth2, X.509, service marketplace, service plans, rate limiting, cf create-service, btp create services/instance, ServiceInstance CRD, ServiceBinding CRD",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "btp",
       "keywords": [
         "api",
@@ -514,7 +514,7 @@
       "name": "sap-cap-capire",
       "source": "./plugins/sap-cap-capire",
       "description": "SAP Cloud Application Programming Model (CAP) development skill using Capire documentation. Use when: building CAP applications, defining CDS models, implementing services, working with SAP HANA/SQLite/PostgreSQL databases, deploying to SAP BTP Cloud Foundry or Kyma, implementing Fiori UIs, handling authorization, multitenancy, or messaging. Covers CDL/CQL/CSN syntax, Node.js and Java runtimes, event handlers, OData services, and CAP plugins.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "cap",
       "keywords": [
         "api",
@@ -557,7 +557,7 @@
       "name": "sap-cloud-sdk-ai",
       "source": "./plugins/sap-cloud-sdk-ai",
       "description": "Integrates SAP Cloud SDK for AI into JavaScript/TypeScript and Java applications. Use when building applications with SAP AI Core, Generative AI Hub, or Orchestration Service. Covers chat completion, embedding, streaming, function calling, content filtering, data masking, document grounding, prompt registry, and LangChain/Spring AI integration. Supports OpenAI GPT-4o, Llama, Gemini, Amazon Nova, and other foundation models via SAP BTP.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "ai",
       "keywords": [
         "artificial intelligence",
@@ -582,7 +582,7 @@
       "name": "sap-cloud-sdk-ai-python",
       "source": "./plugins/sap-cloud-sdk-ai-python",
       "description": "Integrates the SAP Cloud SDK for AI for Python (sap-ai-sdk-gen, formerly generative-ai-hub-sdk) into Python applications. Use when building Python apps with SAP AI Core, Generative AI Hub, or the Orchestration Service: chat completion, embeddings, streaming, LangChain integration, templating, content filtering, data masking, and document grounding. Supports OpenAI GPT models, Llama, Gemini, Amazon Nova, and other foundation models via SAP BTP.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "ai",
       "keywords": [
         "artificial intelligence",
@@ -605,7 +605,7 @@
       "name": "sap-datasphere",
       "source": "./plugins/sap-datasphere",
       "description": "SAP Datasphere development skill with 3 specialized agents, 5 slash commands, and validation hooks. Use when building data warehouses on SAP BTP, creating analytic models, configuring data flows and replication flows, setting up connections, managing spaces and users, implementing data access controls, or using the datasphere CLI. Covers Data Builder, Business Builder, analytic models, 40+ connection types, real-time replication, task chains, content transport, and data marketplace.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "data-analytics",
       "keywords": [
         "analytics",
@@ -638,7 +638,7 @@
       "name": "sap-dependency-security",
       "source": "./plugins/sap-dependency-security",
       "description": "SAP dependency security and MCP executable trust policy with secure upgrades, cooldowns, staged rollout, and supply-chain protection. Use when upgrading deps, configuring security policies, preventing supply chain attacks, pinning SAP MCP servers, or reviewing SAP CAP/UI5/Fiori/HANA/Datasphere/SAC/BTP/ABAP dependency workflows.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "tooling",
       "keywords": [
         "abap",
@@ -666,7 +666,7 @@
       "name": "sap-fiori-tools",
       "source": "./plugins/sap-fiori-tools",
       "description": "Develops SAP Fiori applications using SAP Fiori tools extensions for VS Code and SAP Business Application Studio. Use when: generating Fiori Elements or Freestyle SAPUI5 applications, configuring Page Editor for List Report or Object Page, working with annotations and Service Modeler, setting up deployment to ABAP or Cloud Foundry, creating adaptation projects, using Guided Development, previewing with mock data or live data, configuring SAP Fiori launchpad, or using AI-powered generation with Project Accelerator/Joule. Technologies: SAP Fiori Elements, SAPUI5, OData V2/V4, CAP, SAP BTP, ABAP, Cloud Foundry, fiori-mcp-server (MCP tools for AI-assisted generation).",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "ui-development",
       "keywords": [
         "abap",
@@ -698,7 +698,7 @@
       "name": "sap-hana-cli",
       "source": "./plugins/sap-hana-cli",
       "description": "Assists with SAP HANA Developer CLI (hana-cli) for database development and administration. Use when: installing hana-cli, connecting to SAP HANA databases, inspecting database objects (tables, views, procedures, functions), managing HDI containers, executing SQL queries, converting metadata to CDS/EDMX/OpenAPI formats, managing SAP HANA Cloud instances, working with BTP CLI integration, or troubleshooting hana-cli commands. Covers: 91 commands, 17+ output formats, HDI container management, cloud operations.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "hana",
       "keywords": [
         "api",
@@ -728,7 +728,7 @@
       "name": "sap-hana-cloud-data-intelligence",
       "source": "./plugins/sap-hana-cloud-data-intelligence",
       "description": "Develops data processing pipelines, integrations, and machine learning scenarios in SAP Data Intelligence Cloud. Use when building graphs/pipelines with operators, integrating ABAP/S4HANA systems, creating replication flows, developing ML scenarios with JupyterLab, or using Data Transformation Language functions. Covers Gen1/Gen2 operators, subengines (Python, Node.js, C++), structured data operators, and repository objects.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "hana",
       "keywords": [
         "abap",
@@ -754,7 +754,7 @@
       "name": "sap-hana-ml",
       "source": "./plugins/sap-hana-ml",
       "description": "SAP HANA Machine Learning Python Client (hana-ml) development skill. Use when: Building ML solutions with SAP HANA's in-database machine learning using Python hana-ml library for PAL/APL algorithms, DataFrame operations, AutoML, model persistence, and visualization. Keywords: hana-ml, SAP HANA, machine learning, PAL, APL, predictive analytics, HANA DataFrame, ConnectionContext, classification, regression, clustering, time series, ARIMA, gradient boosting, AutoML, SHAP, model storage",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "hana",
       "keywords": [
         "cloud",
@@ -776,7 +776,7 @@
       "name": "sap-rpt1",
       "source": "./plugins/sap-rpt1",
       "description": "SAP-RPT-1-OSS local tabular prediction workflows for FI/CO prototype datasets. Use when preparing SAP finance CSV exports for classification or regression experiments with source-verified setup, leakage checks, and governance review.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "ai",
       "keywords": [
         "artificial intelligence",
@@ -796,7 +796,7 @@
       "name": "sap-sac-custom-widget",
       "source": "./plugins/sap-sac-custom-widget",
       "description": "SAP Analytics Cloud (SAC) Custom Widget development. Use when building custom visualizations, extending SAC with Web Components, or creating Widget Add-Ons. Covers JSON metadata, JavaScript Web Components, lifecycle functions, data binding with feeds, styling/builder panels, property/event/method definitions, third-party library integration, hosting, security, performance, and debugging. Includes Widget Add-On feature (QRC Q4 2023+) and templates for widgets, charts, and KPI cards.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "data-analytics",
       "keywords": [
         "analytics",
@@ -828,7 +828,7 @@
       "name": "sap-sac-planning",
       "source": "./plugins/sap-sac-planning",
       "description": "SAP Analytics Cloud (SAC) planning guidance for planning models, planning-enabled stories, data actions, multi actions, version management, data locking, calendar/input workflows, allocations, value driver trees, BPC live planning, and Seamless Planning with SAP Datasphere. Use this for planning design, planning APIs, data action debugging, and planning performance reviews; use sap-sac-scripting for non-planning SAC scripts and sap-datasphere for Datasphere modeling.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "data-analytics",
       "keywords": [
         "analytics",
@@ -858,7 +858,7 @@
       "name": "sap-sac-scripting",
       "source": "./plugins/sap-sac-scripting",
       "description": "Comprehensive SAC scripting skill for SAP Analytics Cloud Analytics Designer and Optimized Story Experience. This skill should be used when the user asks to \"create SAC script\", \"debug Analytics Designer\", \"optimize SAC performance\", \"planning operations in SAC\", \"filter data in SAC\", \"use DataSource API\", \"chart scripting\", \"table manipulation\", \"SAC event handlers\", \"version management\", \"data locking\", \"Optimized Story Experience API\", \"OSE scripting\", \"OSE widget API\", \"OSE DataSource\", \"story scripting API\", \"OSE planning API\", \"OSE method\", \"optimized story\", \"SAC story scripting\", \"story script\", \"SAC scripting\", or works with SAC widgets, planning models, or analytics applications.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "data-analytics",
       "keywords": [
         "analytics",
@@ -891,7 +891,7 @@
       "name": "sap-sac-test-automation",
       "source": "./plugins/sap-sac-test-automation",
       "description": "SAP Analytics Cloud (SAC) automated testing skill for designing capability-gated browser discovery and deterministic Playwright test suites for SAC stories, dashboards, reports, planning workflows, comments, permissions, visual regression, and reusable QA automation. This skill should be used when building SAC end-to-end tests, onboarding SAC dashboards into Playwright, creating dashboard profiles or scenario YAML, using Microsoft Edge/CDP, Chrome DevTools MCP, Vercel Labs agent-browser, or manual discovery for SAC components, testing SAC optimized stories, configuring SAC auth storage state, managing visual/data baselines, testing comments, planning writeback, data actions, multi actions, role-based views, restricted Windows/company environments, or creating SAC failure triage artifacts.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "data-analytics",
       "keywords": [
         "analytics",
@@ -920,7 +920,7 @@
       "name": "sap-sqlscript",
       "source": "./plugins/sap-sqlscript",
       "description": "This skill should be used when the user asks to \"write a SQLScript procedure\", \"create HANA stored procedure\", \"implement AMDP method\", \"optimize SQLScript performance\", \"handle SQLScript exceptions\", \"debug HANA procedure\", \"create table function\", or mentions SQLScript, SAP HANA procedures, AMDP, EXIT HANDLER, or code-to-data paradigm. Comprehensive SQLScript development guidance for SAP HANA database programming including syntax patterns, built-in functions, exception handling, performance optimization, cursor management, and ABAP Managed Database Procedure (AMDP) integration.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "data-analytics",
       "keywords": [
         "abap",
@@ -953,7 +953,7 @@
       "name": "sapui5",
       "source": "./plugins/sapui5",
       "description": "This skill should be used when developing SAP UI5 applications, including creating freestyle apps, Fiori Elements apps, custom controls, testing, data binding, OData integration, routing, and troubleshooting. Use when building enterprise web applications with SAP UI5 framework, implementing MVC patterns, configuring manifest.json, creating XML views, writing controllers, setting up data models (JSON, OData v2/v4), implementing responsive UI with sap.m controls, building Fiori Elements apps, writing unit tests with QUnit, integration tests with OPA5, setting up mock servers, handling security (XSS, CSP), optimizing performance, implementing accessibility features, or debugging UI5 applications. Also covers sap.ui.mdc controls and TypeScript control libraries.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "ui-development",
       "keywords": [
         "components",
@@ -987,7 +987,7 @@
       "name": "sapui5-cli",
       "source": "./plugins/sapui5-cli",
       "description": "Manages SAPUI5/OpenUI5 projects using the UI5 Tooling CLI (@ui5/cli). Use when initializing UI5 projects, configuring ui5.yaml or ui5-workspace.yaml files, building UI5 applications or libraries, running development servers with HTTP/2 support, creating custom build tasks or server middleware, managing workspace/monorepo setups, troubleshooting UI5 CLI errors, migrating between UI5 CLI versions, or optimizing build performance. Supports both OpenUI5 and SAPUI5 frameworks with complete configuration and extensibility guidance.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "ui-development",
       "keywords": [
         "cli",
@@ -1010,7 +1010,7 @@
       "name": "sapui5-linter",
       "source": "./plugins/sapui5-linter",
       "description": "Use this skill when working with the UI5 Linter (@ui5/linter) for static code analysis of SAPUI5/OpenUI5 applications and libraries. Covers setup, configuring linting rules, running the linter to detect deprecated APIs, global variable usage, CSP violations, and manifest issues. Supports autofix for deprecated API usage, global references, event handlers, and manifest properties. Includes CI/CD integration, pre-commit hooks, and UI5 2.x migration preparation.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "ui-development",
       "keywords": [
         "api",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to SAP Skills will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-06-19
+
+### Added
+- Added `sap-sac-test-automation` for SAP Analytics Cloud browser and Playwright automation, including dashboard profile/scenario guidance, governance and testability notes, failure-triage artifacts, Edge/CDP patterns, Chrome DevTools MCP coverage, and `/sac-test-onboard`.
+- Added `sap-rpt1` for SAP-RPT-1-OSS FI/CO local tabular prediction workflows, including prepare/predict commands, sample FI/CO datasets, leakage checks, governance guidance, enterprise portability notes, and source-review evidence.
+- Added CAP CDS LSP launcher support and exposed the CAP LSP configuration through generated plugin and marketplace metadata.
+- Added SAC custom widget design/runtime guidance, AI-assisted composite generation notes, CSS/styling compliance coverage, browser runtime references, and design-runtime templates.
+- Added an SAP Integration Suite HTTPS-to-SFTP iFlow package authoring reference and reusable template package.
+- Added Oracle shared review tooling and multi-harness portability documentation for using the same SAP skills across supported AI coding assistants.
+
+### Changed
+- Bumped the coordinated repository, marketplace, plugin manifest, and skill metadata versions to 2.3.1.
+- Updated README and current-state marketplace documentation for the 37-plugin inventory: 64 commands, 31 agents, 8 hook-enabled plugins, 6 MCP-enabled plugins, and 1 LSP-enabled plugin.
+- Strengthened validation coverage for manifest drift, MCP security and environment contracts, packaging hygiene, public claims, Oracle browser safety, reference provenance, templates, command/agent contracts, hook contracts, and skill quality.
+- Improved multi-harness wording and evidence language so Claude-specific sidecars are described as portable guidance where clients do not support them natively.
+
+### Fixed
+- Removed outdated website planning documents and stale marketplace backup artifacts from the packaged repository state.
+- Addressed SAP-RPT-1 follow-up review items, including third-party attribution cleanup.
+
 ## [2.3.0] - 2026-06-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,13 +3,13 @@
 
 **Repository**: https://github.com/secondsky/sap-skills
 **Purpose**: SAP development skills for AI coding assistants with evidence-tracked verification
-**Version**: 2.3.0 | **Plugins**: 35 | **Last Updated**: 2026-06-14
+**Version**: 2.3.1 | **Plugins**: 37 | **Last Updated**: 2026-06-19
 
 ---
 
 ## What This Repository Is
 
-36 SAP development skills for SAP technologies: BTP, CAP, Fiori, ABAP,
+37 SAP development skills for SAP technologies: BTP, CAP, Fiori, ABAP,
 Analytics, and more. Public-source/package-registry verification is tracked
 where available; live tenant/system validation is tracked per plugin in
 `docs/project/source-verification-ledger.json`.
@@ -121,7 +121,7 @@ prefer `preset: "chatgpt-pro-heavy"` or explicit `engine: "browser"`.
 
 ### Marketplace System
 
-**Scale**: 36 plugins with coordinated versioning
+**Scale**: 37 plugins with coordinated versioning
 **Structure**: Single root manifest per plugin (`plugins/*/.claude-plugin/plugin.json`)
 **Registry**: Central marketplace.json (~40KB, auto-generated)
 **Cross-References**: 15 plugins reference related skills
@@ -154,7 +154,7 @@ prefer `preset: "chatgpt-pro-heavy"` or explicit `engine: "browser"`.
 **Version Tracking**: SAP SDK versions documented in metadata
 ```yaml
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   cap_version: "@sap/cds 9.4.x"
   last_verified: "2025-12-28"
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](LICENSE)
 [![Plugins](https://img.shields.io/badge/Plugins-37-brightgreen.svg)](.claude-plugin/marketplace.json)
-[![Version](https://img.shields.io/badge/Version-2.3.0-orange.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-2.3.1-orange.svg)](CHANGELOG.md)
 
 SAP development plugins for AI coding assistants, with public-source or package-registry verification tracked where available. Live tenant and system validation is tracked per plugin in `docs/project/source-verification-ledger.json`.
 
@@ -251,4 +251,4 @@ Open source under **GPL-3.0**. Contributions welcome:
 
 ---
 
-**Maintained by**: E.J. · **Repository**: [github.com/secondsky/sap-skills](https://github.com/secondsky/sap-skills) · **Last Updated**: 2026-06-14 (v2.3.0)
+**Maintained by**: E.J. · **Repository**: [github.com/secondsky/sap-skills](https://github.com/secondsky/sap-skills) · **Last Updated**: 2026-06-19 (v2.3.1)

--- a/docs/architecture/marketplace-infrastructure.md
+++ b/docs/architecture/marketplace-infrastructure.md
@@ -8,13 +8,13 @@ Technical documentation for the SAP Skills marketplace system.
 
 ## Overview
 
-The SAP skills repository uses a **marketplace system** to manage 35 production plugins with:
-- Coordinated versioning (all at v2.3.0)
+The SAP skills repository uses a **marketplace system** to manage 37 production plugins with:
+- Coordinated versioning (all at v2.3.1)
 - Cross-references between related skills
 - Central registry (.claude-plugin/marketplace.json)
 - Single root manifest architecture
 
-**Scale**: 35 plugins across 8 manifest categories (`abap`, `ai`, `btp`, `cap`, `data-analytics`, `hana`, `tooling`, `ui-development`)
+**Scale**: 37 plugins across 8 manifest categories (`abap`, `ai`, `btp`, `cap`, `data-analytics`, `hana`, `tooling`, `ui-development`)
 
 ---
 
@@ -22,25 +22,26 @@ The SAP skills repository uses a **marketplace system** to manage 35 production 
 
 ### Skill Families
 
-**Tooling & Development** (2 plugins):
-- sap-api-style, sap-dependency-security
+**Tooling & Development** (3 plugins):
+- sap-api-style, sap-dependency-security, sap-hana-cli
 
-**SAP BTP Platform** (14 skills):
+**SAP BTP Platform** (15 plugins):
 - sap-btp-best-practices, sap-btp-build-work-zone-advanced, sap-btp-business-application-studio,
-  sap-btp-cias, sap-btp-cloud-logging, sap-btp-cloud-platform, sap-btp-cloud-transport-management,
-  sap-btp-connectivity, sap-btp-developer-guide, sap-btp-integration-suite,
+  sap-btp-cias, sap-btp-cloud-identity-services, sap-btp-cloud-logging, sap-btp-cloud-platform,
+  sap-btp-cloud-transport-management, sap-btp-connectivity, sap-btp-developer-guide, sap-btp-integration-suite,
   sap-btp-intelligent-situation-automation, sap-btp-job-scheduling, sap-btp-master-data-integration,
   sap-btp-service-manager
 
-**UI Development** (4 skills):
+**UI Development** (4 plugins):
 - sap-fiori-tools, sapui5, sapui5-cli, sapui5-linter
 
-**Data & Analytics** (5 skills):
+**Data & Analytics** (6 plugins):
 - sap-datasphere, sap-sac-custom-widget, sap-sac-planning, sap-sac-scripting,
-  sap-hana-cloud-data-intelligence
+  sap-hana-cloud-data-intelligence, sap-sac-test-automation
 
-**Core Technologies** (7 plugins):
-- sap-abap, sap-abap-cds, sap-cap-capire, sap-sqlscript, sap-ai-core, sap-cloud-sdk-ai, sap-hana-ml
+**Core Technologies** (9 plugins):
+- sap-abap, sap-abap-cds, sap-cap-capire, sap-sqlscript, sap-ai-core, sap-cloud-sdk-ai,
+  sap-cloud-sdk-ai-python, sap-hana-ml, sap-rpt1
 
 ### Cross-Reference Pattern
 
@@ -69,8 +70,8 @@ This enables Claude to:
 3. Script propagates version to all plugin.json files
 4. Commit all changes together
 
-**Current Version**: 2.3.0
-**Last Updated**: 2026-06-14
+**Current Version**: 2.3.1
+**Last Updated**: 2026-06-19
 
 ---
 
@@ -108,18 +109,18 @@ plugins/sap-cap-capire/
 ### marketplace.json Structure
 
 **Location**: `.claude-plugin/marketplace.json`
-**Size**: ~40KB (35 plugins)
+**Size**: ~40KB (37 plugins)
 **Auto-Generated**: By `generate-marketplace.sh`
 
 **Structure**:
 ```json
 {
   "name": "sap-skills",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "metadata": {
-    "version": "2.3.0",
-    "last_updated": "2026-06-14",
-    "total_skills": 35,
+    "version": "2.3.1",
+    "last_updated": "2026-06-19",
+    "total_skills": 37,
     "categories": [
       "abap", "ai", "btp", "cap",
       "data-analytics", "hana",
@@ -130,7 +131,7 @@ plugins/sap-cap-capire/
     {
       "name": "sap-cap-capire",
       "description": "...",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "source": "plugins/sap-cap-capire",
       "license": "GPL-3.0",
       "keywords": [...],
@@ -159,7 +160,7 @@ cd sap-skills
 
 ### Cross-References Between Skills
 
-**13 skills** have marketplace cross-references via keywords:
+**15 skills** have marketplace cross-references via keywords:
 
 Example from sap-cap-capire:
 ```yaml
@@ -182,5 +183,5 @@ This enables portfolio-wide skill discovery.
 
 ---
 
-**Last Updated**: 2026-06-14
+**Last Updated**: 2026-06-19
 **Maintainer**: SAP Skills Repository Team

--- a/docs/contributor-guide/README.md
+++ b/docs/contributor-guide/README.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide for developing, maintaining, and publishing SAP skills for Claude Code.
 
-**Version**: 2.3.0 | **Last Updated**: 2026-06-14
+**Version**: 2.3.1 | **Last Updated**: 2026-06-19
 
 ---
 
@@ -208,29 +208,29 @@ npm outdated  # Check for SAP package updates
 
 ### Overview
 
-The SAP skills repository manages **35 production plugins** using a marketplace system with:
-- Coordinated versioning (all at v2.3.0)
+The SAP skills repository manages **37 production plugins** using a marketplace system with:
+- Coordinated versioning (all at v2.3.1)
 - Cross-references between related skills
 - Central registry (.claude-plugin/marketplace.json)
 - Single root manifest architecture
 
-**Scale**: 35 plugins across 5 user-facing groups:
-- Tooling & Development (2 plugins)
-- SAP BTP Platform (15 skills)
-- UI Development (4 skills)
-- Data & Analytics (5 skills)
-- Core Technologies (7 skills)
+**Scale**: 37 plugins across 5 user-facing groups:
+- Tooling & Development (3 plugins)
+- SAP BTP Platform (15 plugins)
+- UI Development (4 plugins)
+- Data & Analytics (6 plugins)
+- Core Technologies (9 plugins)
 
 ### Key Concepts
 
 #### Skill Families
 
 Skills are organized into families for better discoverability:
-- **BTP Platform**: 14 skills covering Cloud Foundry, services, integration
-- **Core Technologies**: CAP, ABAP, HANA, AI/ML (7 skills)
-- **UI Development**: Fiori, SAPUI5, tooling (4 skills)
-- **Data & Analytics**: SAC, Datasphere, Data Intelligence (5 skills)
-- **Tooling**: API style guidance and dependency upgrade hardening (2 plugins)
+- **BTP Platform**: 15 plugins covering Cloud Foundry, services, integration
+- **Core Technologies**: CAP, ABAP, HANA, AI/ML, and FI/CO prediction workflows (9 plugins)
+- **UI Development**: Fiori, SAPUI5, tooling (4 plugins)
+- **Data & Analytics**: SAC, Datasphere, Data Intelligence, and SAC test automation (6 plugins)
+- **Tooling**: API style guidance, dependency security, and HANA CLI operations (3 plugins)
 
 #### Cross-References
 
@@ -247,7 +247,7 @@ This enables Claude to discover complementary skills automatically.
 
 **Single Source of Truth**: `marketplace.json` metadata.version field
 
-All plugins share the same version (currently 2.3.0) and are updated together:
+All plugins share the same version (currently 2.3.1) and are updated together:
 ```bash
 # Update version in marketplace.json
 vim .claude-plugin/marketplace.json
@@ -332,7 +332,7 @@ Every SAP skill must document SDK versions:
 ---
 name: sap-cap-capire
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   cap_version: "@sap/cds 9.4.x"
   last_verified: "2025-12-28"
   sap_btp_compatible: true
@@ -678,8 +678,8 @@ NOT:
 ./scripts/generate-marketplace.sh --dry-run
 
 # Validate output
-jq '.plugins | length' .claude-plugin/marketplace.json  # Should be 35
-jq '.metadata.total_skills' .claude-plugin/marketplace.json  # Should be 35
+jq '.plugins | length' .claude-plugin/marketplace.json  # Should be 37
+jq '.metadata.total_skills' .claude-plugin/marketplace.json  # Should be 37
 ```
 
 ---
@@ -709,7 +709,7 @@ jq '.metadata.total_skills' .claude-plugin/marketplace.json  # Should be 35
 3. **Update skill metadata**:
    ```yaml
    metadata:
-     version: "2.3.0"
+     version: "2.3.1"
      cap_version: "@sap/cds 9.5.x"  # Updated
      last_verified: "2026-03-28"     # Updated
    ```
@@ -854,7 +854,7 @@ https://github.com/secondsky/sap-skills/issues
 
 ---
 
-**Last Updated**: 2026-06-14
+**Last Updated**: 2026-06-19
 **Next Review**: 2026-08-31 (Quarterly)
-**Version**: 2.3.0
+**Version**: 2.3.1
 **Maintainer**: SAP Skills Repository Team | [github.com/secondsky/sap-skills](https://github.com/secondsky/sap-skills)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -262,7 +262,7 @@ This project is licensed under the GNU General Public License v3.0 (GPL-3.0) - s
 
 ---
 
-**Last Updated**: 2026-06-14
-**Marketplace Version**: 2.3.0
-**Skills**: 35
+**Last Updated**: 2026-06-19
+**Marketplace Version**: 2.3.1
+**Skills**: 37
 **Maintainer**: SAP Skills Maintainers

--- a/docs/reference/sap-development-patterns.md
+++ b/docs/reference/sap-development-patterns.md
@@ -3,8 +3,8 @@
 > **SAP-specific patterns for Claude Code skills.** For general plugin development,
 > use the official **plugin-dev skills** FIRST.
 
-**Last Updated**: 2026-06-14
-**Version**: 2.3.0
+**Last Updated**: 2026-06-19
+**Version**: 2.3.1
 **Repository**: [github.com/secondsky/sap-skills](https://github.com/secondsky/sap-skills)
 
 ---
@@ -116,37 +116,38 @@ npm outdated  # Check for SAP package updates
 
 ### Overview
 
-The SAP skills repository uses a **marketplace system** to manage 35 production plugins with:
-- Coordinated versioning (all at v2.3.0)
+The SAP skills repository uses a **marketplace system** to manage 37 production plugins with:
+- Coordinated versioning (all at v2.3.1)
 - Cross-references between related skills
 - Central registry (.claude-plugin/marketplace.json)
 - Single root manifest architecture
 
-**Scale**: 35 plugins across 8 manifest categories and 5 user-facing groups.
+**Scale**: 37 plugins across 8 manifest categories and 5 user-facing groups.
 
 ### Multi-Skill Portfolio Management
 
 #### Skill Families
 
-**Tooling & Development** (2 plugins):
-- sap-api-style, sap-dependency-security
+**Tooling & Development** (3 plugins):
+- sap-api-style, sap-dependency-security, sap-hana-cli
 
-**SAP BTP Platform** (14 skills):
+**SAP BTP Platform** (15 plugins):
 - sap-btp-best-practices, sap-btp-build-work-zone-advanced, sap-btp-business-application-studio,
-  sap-btp-cias, sap-btp-cloud-logging, sap-btp-cloud-platform, sap-btp-cloud-transport-management,
-  sap-btp-connectivity, sap-btp-developer-guide, sap-btp-integration-suite,
+  sap-btp-cias, sap-btp-cloud-identity-services, sap-btp-cloud-logging, sap-btp-cloud-platform,
+  sap-btp-cloud-transport-management, sap-btp-connectivity, sap-btp-developer-guide, sap-btp-integration-suite,
   sap-btp-intelligent-situation-automation, sap-btp-job-scheduling, sap-btp-master-data-integration,
   sap-btp-service-manager
 
-**UI Development** (4 skills):
+**UI Development** (4 plugins):
 - sap-fiori-tools, sapui5, sapui5-cli, sapui5-linter
 
-**Data & Analytics** (5 skills):
+**Data & Analytics** (6 plugins):
 - sap-datasphere, sap-sac-custom-widget, sap-sac-planning, sap-sac-scripting,
-  sap-hana-cloud-data-intelligence
+  sap-hana-cloud-data-intelligence, sap-sac-test-automation
 
-**Core Technologies** (7 plugins):
-- sap-abap, sap-abap-cds, sap-cap-capire, sap-sqlscript, sap-ai-core, sap-cloud-sdk-ai, sap-hana-ml
+**Core Technologies** (9 plugins):
+- sap-abap, sap-abap-cds, sap-cap-capire, sap-sqlscript, sap-ai-core, sap-cloud-sdk-ai,
+  sap-cloud-sdk-ai-python, sap-hana-ml, sap-rpt1
 
 #### Cross-Reference Pattern
 
@@ -175,8 +176,8 @@ This enables Claude to:
 3. Script propagates version to all plugin.json files
 4. Commit all changes together
 
-**Current Version**: 2.3.0
-**Last Updated**: 2026-06-14
+**Current Version**: 2.3.1
+**Last Updated**: 2026-06-19
 
 ### Single Root Manifest Architecture
 
@@ -210,18 +211,18 @@ plugins/sap-cap-capire/
 #### marketplace.json Structure
 
 **Location**: `.claude-plugin/marketplace.json`
-**Size**: ~40KB (35 plugins)
+**Size**: ~40KB (37 plugins)
 **Auto-Generated**: By `generate-marketplace.sh`
 
 **Structure**:
 ```json
 {
   "name": "sap-skills",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "metadata": {
-    "version": "2.3.0",
-    "last_updated": "2026-06-14",
-    "total_skills": 35,
+    "version": "2.3.1",
+    "last_updated": "2026-06-19",
+    "total_skills": 37,
     "categories": [
       "abap", "ai", "btp", "cap",
       "data-analytics", "hana",
@@ -232,7 +233,7 @@ plugins/sap-cap-capire/
     {
       "name": "sap-cap-capire",
       "description": "...",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "source": "plugins/sap-cap-capire",
       "license": "GPL-3.0",
       "keywords": [...],
@@ -363,7 +364,7 @@ description: |
   Use when building CAP services, defining CDS models, or implementing
   CAP best practices.
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   cap_version: "@sap/cds 9.4.x"
   last_verified: "2025-12-28"
   sap_btp_compatible: true
@@ -719,7 +720,7 @@ hana-cli deploy             # Deploy database artifacts
 
 **Output**:
 ```
-✓ Reading version from marketplace.json: 2.3.0
+✓ Reading version from marketplace.json: 2.3.1
 ✓ Generating plugin manifests...
   - sap-cap-capire: Updated
   - sap-btp-cloud-platform: Updated
@@ -804,11 +805,11 @@ NOT:
 ```json
 {
   "name": "sap-skills",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "metadata": {
-    "version": "2.3.0",
+    "version": "2.3.1",
     "last_updated": "2025-12-28T12:00:00Z",
-    "total_skills": 35,
+    "total_skills": 37,
     "categories": ["abap", "ai", "btp", "cap", "data-analytics", "hana", "tooling", "ui-development"]
   },
   "plugins": [ ... 33 entries ... ]
@@ -824,8 +825,8 @@ NOT:
 ./scripts/generate-marketplace.sh --dry-run
 
 # Validate output
-jq '.plugins | length' .claude-plugin/marketplace.json  # Should be 35
-jq '.metadata.total_skills' .claude-plugin/marketplace.json  # Should be 35
+jq '.plugins | length' .claude-plugin/marketplace.json  # Should be 37
+jq '.metadata.total_skills' .claude-plugin/marketplace.json  # Should be 37
 ```
 
 ---
@@ -855,7 +856,7 @@ jq '.metadata.total_skills' .claude-plugin/marketplace.json  # Should be 35
 3. **Update skill metadata**:
    ```yaml
    metadata:
-     version: "2.3.0"
+     version: "2.3.1"
      cap_version: "@sap/cds 9.5.x"  # Updated
      last_verified: "2026-03-28"     # Updated
    ```
@@ -981,6 +982,6 @@ https://github.com/secondsky/sap-skills/issues
 
 ---
 
-**Last Updated**: 2026-06-14
+**Last Updated**: 2026-06-19
 **Next Review**: 2026-08-31 (Quarterly)
 **Maintainer**: SAP Skills Maintainers | [github.com/secondsky/sap-skills](https://github.com/secondsky/sap-skills)

--- a/docs/validation/IMPLEMENTATION.md
+++ b/docs/validation/IMPLEMENTATION.md
@@ -287,7 +287,7 @@ Fix the validation errors above, or bypass with: git commit --no-verify
 ### For Maintainers
 - **Prevents Invalid Data**: Bad data never enters Git history
 - **Automated Quality Gates**: No manual schema checking needed
-- **Consistent Standards**: All 35 plugins follow same structure
+- **Consistent Standards**: All 37 plugins follow same structure
 - **Self-Documenting**: Schemas serve as structure documentation
 
 ### For the Project

--- a/plugins/sap-abap-cds/.claude-plugin/plugin.json
+++ b/plugins/sap-abap-cds/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-abap-cds",
   "description": "Comprehensive SAP ABAP CDS (Core Data Services) reference for data modeling, view development, and semantic enrichment. Use when creating CDS views or view entities, defining data models with annotations, working with associations and cardinality, implementing input parameters, using built-in functions, writing CASE expressions, implementing access control with DCL, handling CURR/QUAN data types, troubleshooting CDS errors, querying CDS views from ABAP, or displaying data with SALV IDA. Covers ABAP 7.4+ through ABAP Cloud.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-abap-cds/skills/sap-abap-cds/SKILL.md
+++ b/plugins/sap-abap-cds/skills/sap-abap-cds/SKILL.md
@@ -3,7 +3,7 @@ name: sap-abap-cds
 description: "Comprehensive SAP ABAP CDS (Core Data Services) reference for data modeling, view development, and semantic enrichment. Use when creating CDS views or view entities, defining data models with annotations, working with associations and cardinality, implementing input parameters, using built-in functions, writing CASE expressions, implementing access control with DCL, handling CURR/QUAN data types, troubleshooting CDS errors, querying CDS views from ABAP, or displaying data with SALV IDA. Covers ABAP 7.4+ through ABAP Cloud."
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-04-02"
   abap_release: "7.4 SP8+ / 7.50+ / ABAP Cloud"
   sources:

--- a/plugins/sap-abap/.claude-plugin/plugin.json
+++ b/plugins/sap-abap/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-abap",
   "description": "Comprehensive ABAP development skill for SAP systems. Use when writing ABAP code, working with internal tables, structures, ABAP SQL, object-oriented programming, RAP (RESTful Application Programming Model), CDS views, EML statements, ABAP Cloud development, string processing, dynamic programming, RTTI/RTTC, field symbols, data references, exception handling, or ABAP unit testing. Covers both classic ABAP and modern ABAP for Cloud Development patterns.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-abap/skills/sap-abap/SKILL.md
+++ b/plugins/sap-abap/skills/sap-abap/SKILL.md
@@ -9,7 +9,7 @@ description: |
   ABAP and modern ABAP for Cloud Development patterns.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-04-02"
   abap_release: "7.40 SP08+ / 7.50+ / ABAP Cloud"
   sources:

--- a/plugins/sap-ai-core/.claude-plugin/plugin.json
+++ b/plugins/sap-ai-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-ai-core",
   "description": "Guides development with SAP AI Core and SAP AI Launchpad for enterprise AI/ML workloads on SAP BTP. Use when: deploying generative AI models, building orchestration workflows with templating/filtering/grounding, implementing RAG with vector databases, managing ML training pipelines with Argo Workflows, configuring content filtering and data masking for PII protection, using the Generative AI Hub for prompt experimentation, managing prompt templates via the Prompt Registry, or integrating AI capabilities into SAP applications. Covers service plans (Free/Standard/Extended), model providers (Azure OpenAI, AWS Bedrock, GCP Vertex AI, Mistral, IBM, Perplexity), orchestration modules, embeddings, tool calling, and structured outputs.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-ai-core/skills/sap-ai-core/SKILL.md
+++ b/plugins/sap-ai-core/skills/sap-ai-core/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Guides development with SAP AI Core and SAP AI Launchpad for enterprise AI/ML workloads on SAP BTP. Use when: deploying generative AI models, building orchestration workflows with templating/filtering/grounding, implementing RAG with vector databases, managing ML training pipelines with Argo Workflows, configuring content filtering and data masking for PII protection, using the Generative AI Hub for prompt experimentation, managing prompt templates via the Prompt Registry, or integrating AI capabilities into SAP applications. Covers service plans (Free/Standard/Extended), model providers (Azure OpenAI, AWS Bedrock, GCP Vertex AI, Mistral, IBM, Perplexity), orchestration modules, embeddings, tool calling, and structured outputs.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-06-12"
   production_tested: "No; documentation-audited only, no live tenant/runtime evidence"
   runtime_verification: "pending tenant evidence"

--- a/plugins/sap-api-style/.claude-plugin/plugin.json
+++ b/plugins/sap-api-style/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-api-style",
   "description": "This skill provides comprehensive guidance for documenting SAP APIs following the SAP API Style Guide standards. It should be used when creating or reviewing API documentation for REST, OData, Java, JavaScript, .NET, or C/C++ APIs. The skill covers naming conventions, documentation comments, OpenAPI specifications, quality checklists, deprecation policies, and manual documentation templates. It ensures consistency with SAP API Business Hub standards and industry best practices. Keywords: SAP API, REST, OData, OpenAPI, Swagger, Javadoc, JSDoc, XML documentation, API Business Hub, API naming, API deprecation, x-sap-stateInfo, Entity Data Model, EDM, documentation tags, API quality, API templates",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-api-style/skills/sap-api-style/SKILL.md
+++ b/plugins/sap-api-style/skills/sap-api-style/SKILL.md
@@ -11,7 +11,7 @@ description: |
   API deprecation, x-sap-stateInfo, Entity Data Model, EDM, documentation tags, API quality, API templates
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-02-25"
   source_version: "2025.01"
   source_commit: "902247f3afb6a0cb3fa110b284bb5d93a65c1268"
@@ -436,7 +436,7 @@ See individual reference files for complete anti-patterns and fixes.
 
 ---
 
-**Skill Version**: 2.3.0
+**Skill Version**: 2.3.1
 **Last Updated**: 2026-06-14
 **License**: GPL-3.0
 **Maintainer**: SAP Skills Team | [https://github.com/secondsky/sap-skills](https://github.com/secondsky/sap-skills)

--- a/plugins/sap-btp-best-practices/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-best-practices",
   "description": "SAP BTP best practices for enterprise architecture, account management, security, and operations, with verification evidence tracked in the repository ledger. Use when planning BTP implementations, setting up account hierarchies, configuring environments, implementing authentication, designing CI/CD pipelines, establishing governance, building Platform Engineering teams, implementing failover strategies, or managing application lifecycle on SAP BTP. Keywords: SAP BTP, account hierarchy, global account, directory, subaccount, Cloud Foundry, Kyma, ABAP, SAP Identity Authentication, CI/CD, governance, Platform Engineering, failover, multi-region, SAP BTP best practices",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-best-practices/skills/sap-btp-best-practices/SKILL.md
+++ b/plugins/sap-btp-best-practices/skills/sap-btp-best-practices/SKILL.md
@@ -6,7 +6,7 @@ description: |
   Keywords: SAP BTP, account hierarchy, global account, directory, subaccount, Cloud Foundry, Kyma, ABAP, SAP Identity Authentication, CI/CD, governance, Platform Engineering, failover, multi-region, SAP BTP best practices
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
 ---
 

--- a/plugins/sap-btp-build-work-zone-advanced/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-build-work-zone-advanced/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-build-work-zone-advanced",
   "description": "Develops and administers SAP Build Work Zone, advanced edition digital workplace solutions. Use when creating workspaces, workpages, and collaborative sites, developing UI Integration Cards in SAP Business Application Studio, building content packages and workspace templates, integrating with Microsoft 365/Teams/SharePoint/Google Drive, configuring chatbots and webhooks, implementing SCIM API user provisioning, setting up OData business records, managing themes and branding, configuring role-based access and SSO, troubleshooting deployment issues, or working with the Administration Console. Keywords: SAP Build Work Zone advanced edition, digital workplace, UI Integration Cards, content packages, workspace templates, SAP Business Application Studio, SAP Conversational AI, SCIM API, OData, Microsoft Teams integration, SSO, theming, Administration Console",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-build-work-zone-advanced/skills/sap-btp-build-work-zone-advanced/SKILL.md
+++ b/plugins/sap-btp-build-work-zone-advanced/skills/sap-btp-build-work-zone-advanced/SKILL.md
@@ -6,7 +6,7 @@ description: |
   Keywords: SAP Build Work Zone advanced edition, digital workplace, UI Integration Cards, content packages, workspace templates, SAP Business Application Studio, SAP Conversational AI, SCIM API, OData, Microsoft Teams integration, SSO, theming, Administration Console
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
 ---
 

--- a/plugins/sap-btp-business-application-studio/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-business-application-studio/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-business-application-studio",
   "description": "This skill provides comprehensive guidance for SAP Business Application Studio (BAS), the cloud-based IDE on SAP BTP built on Code-OSS. Use when setting up BAS subscriptions, creating dev spaces, connecting to external systems, deploying MTA applications, troubleshooting connectivity issues, managing Git repositories, configuring runtime versions, or using the layout editor. Keywords: SAP Business Application Studio, BAS, SAP BTP, dev space, Cloud Foundry, MTA, multitarget application, SAP Fiori, CAP, HANA, destination, WebIDEEnabled, Cloud Connector, Service Center, Storyboard, Layout Editor, ABAP, OData, subscription, entitlements, role collection, Business_Application_Studio_Developer, Git, clone, push, pull, Gerrit, PAT, OAuth, asdf, runtime, Node.js, Java, Python, Task Explorer, CI/CD, Yeoman, generator, template wizard, mbt, mtar, debugging, breakpoint",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-business-application-studio/skills/sap-btp-business-application-studio/SKILL.md
+++ b/plugins/sap-btp-business-application-studio/skills/sap-btp-business-application-studio/SKILL.md
@@ -6,7 +6,7 @@ description: |
   Keywords: SAP Business Application Studio, BAS, SAP BTP, dev space, Cloud Foundry, MTA, multitarget application, SAP Fiori, CAP, HANA, destination, WebIDEEnabled, Cloud Connector, Service Center, Storyboard, Layout Editor, ABAP, OData, subscription, entitlements, role collection, Business_Application_Studio_Developer, Git, clone, push, pull, Gerrit, PAT, OAuth, asdf, runtime, Node.js, Java, Python, Task Explorer, CI/CD, Yeoman, generator, template wizard, mbt, mtar, debugging, breakpoint
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
 ---
 

--- a/plugins/sap-btp-cias/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cias/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-cias",
   "description": "SAP BTP Cloud Integration Automation Service (CIAS) skill for guided integration workflows. Use when: setting up CIAS subscriptions, configuring destinations, assigning roles (CIASIntegrationAdministrator, CIASIntegrationExpert, CIASIntegrationMonitor), planning integration scenarios, working with My Inbox tasks, monitoring scenario execution, troubleshooting CIAS errors, creating OAuth2 instances, configuring identity providers for CIAS, understanding CIAS security architecture, or integrating SAP products (S/4HANA, SuccessFactors, BTP services, SAP Build, IBP).",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-cias/skills/sap-btp-cias/SKILL.md
+++ b/plugins/sap-btp-cias/skills/sap-btp-cias/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Use when: setting up CIAS subscriptions, configuring destinations, assigning roles (CIASIntegrationAdministrator, CIASIntegrationExpert, CIASIntegrationMonitor), planning integration scenarios, working with My Inbox tasks, monitoring scenario execution, troubleshooting CIAS errors, creating OAuth2 instances, configuring identity providers for CIAS, understanding CIAS security architecture, or integrating SAP products (S/4HANA, SuccessFactors, BTP services, SAP Build, IBP).
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
   sap_product: "Cloud Integration Automation Service"
   source_docs: "https://github.com/SAP-docs/btp-cloud-integration-automation-service"

--- a/plugins/sap-btp-cloud-identity-services/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-identity-services/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-cloud-identity-services",
   "description": "SAP Cloud Identity Services for BTP applications: Identity Authentication (IAS), Identity Provisioning (IPS), and Authorization Management (AMS). Use when configuring authentication for BTP apps, setting up OIDC or SAML app registrations, federating corporate identity providers, establishing subaccount trust, provisioning users, writing AMS authorization policies, migrating from XSUAA to IAS-based authentication, or troubleshooting token and trust errors.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-cloud-identity-services/skills/sap-btp-cloud-identity-services/SKILL.md
+++ b/plugins/sap-btp-cloud-identity-services/skills/sap-btp-cloud-identity-services/SKILL.md
@@ -4,7 +4,7 @@ description: |
   SAP Cloud Identity Services for BTP applications: Identity Authentication (IAS), Identity Provisioning (IPS), and Authorization Management (AMS). Use when configuring authentication for BTP apps, setting up OIDC or SAML app registrations, federating corporate identity providers, establishing subaccount trust, provisioning users, writing AMS authorization policies, migrating from XSUAA to IAS-based authentication, or troubleshooting token and trust errors.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-06-12"
   documentation_source: https://help.sap.com/docs/cloud-identity-services
   ias_docs: https://github.com/SAP-docs/btp-cloud-identity-services

--- a/plugins/sap-btp-cloud-logging/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-logging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-cloud-logging",
   "description": "This skill provides comprehensive guidance for SAP Cloud Logging service on SAP BTP. Use when setting up Cloud Logging instances, configuring log ingestion from Cloud Foundry or Kyma runtimes, implementing OpenTelemetry observability, analyzing logs/metrics/traces in OpenSearch Dashboards, configuring SAML authentication, managing certificates, or troubleshooting ingestion issues. Covers service plans (dev/standard/large), all 4 instance creation methods (BTP Cockpit, CF CLI, BTP CLI, Service Operator), all 4 ingestion methods (Cloud Foundry, Kyma, OpenTelemetry, JSON API), and security best practices.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-cloud-logging/skills/sap-btp-cloud-logging/SKILL.md
+++ b/plugins/sap-btp-cloud-logging/skills/sap-btp-cloud-logging/SKILL.md
@@ -10,7 +10,7 @@ description: |
   ingestion methods (Cloud Foundry, Kyma, OpenTelemetry, JSON API), and security best practices.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
   source_documentation: "https://github.com/SAP-docs/btp-cloud-logging"
   sap_help_portal: "https://help.sap.com/docs/cloud-logging"

--- a/plugins/sap-btp-cloud-platform/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-cloud-platform",
   "description": "Comprehensive SAP Business Technology Platform (BTP) reference for cloud development, deployment, and operations. Use when setting up BTP accounts, working with Cloud Foundry environment, deploying to Kyma (Kubernetes, serverless), developing in ABAP environment (RAP, CDS), managing entitlements and quotas, configuring identity providers (XSUAA), using btp CLI or CF CLI, deploying multi-target applications (MTA), setting up connectivity (destinations, Cloud Connector), implementing CI/CD pipelines, extending SAP solutions, or troubleshooting BTP services. Covers all three runtime environments.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-cloud-platform/skills/sap-btp-cloud-platform/SKILL.md
+++ b/plugins/sap-btp-cloud-platform/skills/sap-btp-cloud-platform/SKILL.md
@@ -3,7 +3,7 @@ name: sap-btp-cloud-platform
 description: "Comprehensive SAP Business Technology Platform (BTP) reference for cloud development, deployment, and operations. Use when setting up BTP accounts, working with Cloud Foundry environment, deploying to Kyma (Kubernetes, serverless), developing in ABAP environment (RAP, CDS), managing entitlements and quotas, configuring identity providers (XSUAA), using btp CLI or CF CLI, deploying multi-target applications (MTA), setting up connectivity (destinations, Cloud Connector), implementing CI/CD pipelines, extending SAP solutions, or troubleshooting BTP services. Covers all three runtime environments."
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
   source: "https://github.com/SAP-docs/sap-btp-cloud-platform"
   keywords: [SAP BTP, Business Technology Platform, Cloud Foundry, Kyma, ABAP environment, subaccount, global account, entitlements, btp CLI, CF CLI, MTA, multi-target application, XSUAA, Cloud Identity Services, destinations, Cloud Connector, service binding, Kubernetes, serverless, RAP, CDS, CAP, CI/CD, extensions, trial account, free tier, enterprise account, CPEA, BTPEA, role collections, Neo environment, Helm, Docker, Istio, API Gateway, Eventing]

--- a/plugins/sap-btp-cloud-transport-management/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-cloud-transport-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-cloud-transport-management",
   "description": "Comprehensive skill for SAP Cloud Transport Management service on SAP BTP. Use when setting up transport landscapes, configuring transport nodes and routes, managing import queues, deploying MTAs across Cloud Foundry environments, integrating with CI/CD pipelines, configuring ABAP environment transports, troubleshooting deployment errors, or implementing change management workflows. Covers entitlements, subscriptions, role collections, service instances, destinations, and API integrations.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-cloud-transport-management/skills/sap-btp-cloud-transport-management/SKILL.md
+++ b/plugins/sap-btp-cloud-transport-management/skills/sap-btp-cloud-transport-management/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Comprehensive skill for SAP Cloud Transport Management service on SAP BTP. Use when setting up transport landscapes, configuring transport nodes and routes, managing import queues, deploying MTAs across Cloud Foundry environments, integrating with CI/CD pipelines, configuring ABAP environment transports, troubleshooting deployment errors, or implementing change management workflows. Covers entitlements, subscriptions, role collections, service instances, destinations, and API integrations.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
   sap_documentation_source: "https://help.sap.com/docs/cloud-transport-management"
 ---

--- a/plugins/sap-btp-connectivity/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-connectivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-connectivity",
   "description": "SAP BTP Connectivity skill covering Destination Service, Connectivity Service, Cloud Connector, Connectivity Proxy, and Transparent Proxy for Kubernetes. Use when configuring destinations (HTTP, RFC, LDAP, MAIL, TCP), setting up cloud-to-on-premise connectivity, implementing OAuth and principal propagation, deploying connectivity proxies in Kubernetes/Kyma, troubleshooting connectivity errors (405, 407, 503), or configuring multitenancy.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-connectivity/skills/sap-btp-connectivity/SKILL.md
+++ b/plugins/sap-btp-connectivity/skills/sap-btp-connectivity/SKILL.md
@@ -3,7 +3,7 @@ name: sap-btp-connectivity
 description: "SAP BTP Connectivity skill covering Destination Service, Connectivity Service, Cloud Connector, Connectivity Proxy, and Transparent Proxy for Kubernetes. Use when configuring destinations (HTTP, RFC, LDAP, MAIL, TCP), setting up cloud-to-on-premise connectivity, implementing OAuth and principal propagation, deploying connectivity proxies in Kubernetes/Kyma, troubleshooting connectivity errors (405, 407, 503), or configuring multitenancy."
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
   keywords: [SAP BTP, Connectivity, Destination Service, Cloud Connector, Connectivity Proxy, Transparent Proxy, Kyma, Kubernetes, OAuth, Principal Propagation, RFC, LDAP, on-premise, hybrid connectivity, service channels, SOCKS5, reverse proxy, tunnel]
 ---

--- a/plugins/sap-btp-developer-guide/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-developer-guide/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-developer-guide",
   "description": "Develops business applications on SAP Business Technology Platform (BTP) using CAP (Node.js/Java) or ABAP Cloud.  Use when: building cloud applications on SAP BTP, deploying to Cloud Foundry or Kyma runtimes, integrating with SAP HANA Cloud, implementing SAP Fiori UIs, connecting to remote SAP systems, building multitenant SaaS applications, extending SAP S/4HANA or SuccessFactors, setting up CI/CD pipelines, implementing observability, or following SAP development best practices. Keywords: SAP BTP, Business Technology Platform, CAP, Cloud Application Programming Model, ABAP Cloud, Cloud Foundry, Kyma, SAP HANA Cloud, SAP Fiori, SAPUI5, CI/CD, observability, multitenant, SaaS, SAP BTP ABAP environment, SAP Business Application Studio, SAP Cloud SDK, SAP Integration Suite, SAP Event Mesh, SAP Connectivity Service, SAP Destination Service, XSUAA, OAuth, OpenID Connect, OData, CDS, Core Data Services, ABAP CDS, ABAP RESTful Application Programming Model, RAP, ABAP development, SAP BTP development",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-developer-guide/skills/sap-btp-developer-guide/SKILL.md
+++ b/plugins/sap-btp-developer-guide/skills/sap-btp-developer-guide/SKILL.md
@@ -8,7 +8,7 @@ description: |
   Keywords: SAP BTP, Business Technology Platform, CAP, Cloud Application Programming Model, ABAP Cloud, Cloud Foundry, Kyma, SAP HANA Cloud, SAP Fiori, SAPUI5, CI/CD, observability, multitenant, SaaS, SAP BTP ABAP environment, SAP Business Application Studio, SAP Cloud SDK, SAP Integration Suite, SAP Event Mesh, SAP Connectivity Service, SAP Destination Service, XSUAA, OAuth, OpenID Connect, OData, CDS, Core Data Services, ABAP CDS, ABAP RESTful Application Programming Model, RAP, ABAP development, SAP BTP development
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2025-11-27
   source_last_updated: 2025-11-21
   review_status: "Complete - Phase 1-14 audit"

--- a/plugins/sap-btp-integration-suite/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-integration-suite/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-integration-suite",
   "description": "Enterprise integration solutions using SAP Integration Suite on BTP. Covers Cloud Integration (iFlows), API Management, Event Mesh, Edge Integration Cell, Integration Advisor, Trading Partner Management, and Migration Assessment. Use for building integration flows, managing API proxies, event-driven architectures, B2B/EDI integrations, hybrid deployments, adapter configuration, Groovy/JavaScript message processing, and troubleshooting.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-integration-suite/skills/sap-btp-integration-suite/SKILL.md
+++ b/plugins/sap-btp-integration-suite/skills/sap-btp-integration-suite/SKILL.md
@@ -5,7 +5,7 @@ description: "Enterprise integration solutions using SAP Integration Suite on BT
 
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2025-11-27
   documentation_source: "https://github.com/SAP-docs/sap-btp-integration-suite"
   sap_help_portal: "https://help.sap.com/docs/integration-suite"

--- a/plugins/sap-btp-intelligent-situation-automation/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-intelligent-situation-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-intelligent-situation-automation",
   "description": "This archived skill provides legacy guidance for SAP BTP Intelligent Situation Automation data export, unsubscription, and configuration review. It should be used only when maintaining existing ISA tenants, exporting data before access is removed, or understanding historical situation automation setups. The skill covers Event Mesh integration, destination configuration, system onboarding, user management with role collections, automatic situation resolution, unsubscription, and troubleshooting for existing deployments. Keywords: SAP BTP, Intelligent Situation Automation, ISA, situation handling, SAP S/4HANA, SAP S/4HANA Cloud, Event Mesh, Business Event Handling, situation automation, situation dashboard, analyze situations, SAP_COM_0345, SAP_COM_0376, SAP_COM_0092, SituationAutomationKeyUser, SituationAutomationAdminUser, Cloud Connector, cf-eu10, CA-SIT-ATM, business situations, situation types, situation actions",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-intelligent-situation-automation/skills/sap-btp-intelligent-situation-automation/SKILL.md
+++ b/plugins/sap-btp-intelligent-situation-automation/skills/sap-btp-intelligent-situation-automation/SKILL.md
@@ -13,7 +13,7 @@ description: |
   Cloud Connector, cf-eu10, CA-SIT-ATM, business situations, situation types, situation actions
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
   status: "ARCHIVED"
   deprecation_date: "2025-09-24"
@@ -355,7 +355,7 @@ For any questions or concerns about the deprecation:
 
 ---
 
-**Skill Version**: 2.3.0
+**Skill Version**: 2.3.1
 **Status**: ARCHIVED / DEPRECATED
 **Last Updated**: 2026-05-31
 **License**: GPL-3.0

--- a/plugins/sap-btp-job-scheduling/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-job-scheduling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-job-scheduling",
   "description": "This skill provides comprehensive guidance for SAP BTP Job Scheduling Service development, configuration, and operations. It should be used when creating, managing, or troubleshooting scheduled jobs on SAP Business Technology Platform. The skill covers service setup, REST API usage, schedule types and formats, OAuth 2.0 authentication, multitenancy, Cloud Foundry tasks, Kyma runtime integration, and monitoring with SAP Cloud ALM and Alert Notification Service. Keywords: SAP BTP, Job Scheduling, jobscheduler, cron, schedule, recurring jobs, one-time jobs, Cloud Foundry tasks, CF tasks, Kyma, OAuth 2.0, XSUAA, @sap/jobs-client, REST API, asynchronous jobs, action endpoint, run logs, SAP Cloud ALM, Alert Notification Service, multitenancy, tenant-aware, BC-CP-CF-JBS",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-job-scheduling/skills/sap-btp-job-scheduling/SKILL.md
+++ b/plugins/sap-btp-job-scheduling/skills/sap-btp-job-scheduling/SKILL.md
@@ -12,7 +12,7 @@ description: |
   SAP Cloud ALM, Alert Notification Service, multitenancy, tenant-aware, BC-CP-CF-JBS
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
 ---
 

--- a/plugins/sap-btp-master-data-integration/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-master-data-integration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-master-data-integration",
   "description": "Configures and integrates SAP Master Data Integration (MDI) service on SAP Business Technology Platform. Use when setting up MDI tenants, connecting applications (S/4HANA, SuccessFactors, Ariba, Fieldglass, etc.), configuring distribution models, SOAP APIs for business partners, extensibility, or troubleshooting master data replication. Covers One Domain Model integration, Business Data Orchestration, client authentication (OAuth2, mTLS), and security configurations.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-master-data-integration/skills/sap-btp-master-data-integration/SKILL.md
+++ b/plugins/sap-btp-master-data-integration/skills/sap-btp-master-data-integration/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Configures and integrates SAP Master Data Integration (MDI) service on SAP Business Technology Platform. Use when setting up MDI tenants, connecting applications (S/4HANA, SuccessFactors, Ariba, Fieldglass, etc.), configuring distribution models, SOAP APIs for business partners, extensibility, or troubleshooting master data replication. Covers One Domain Model integration, Business Data Orchestration, client authentication (OAuth2, mTLS), and security configurations.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
 ---
 

--- a/plugins/sap-btp-service-manager/.claude-plugin/plugin.json
+++ b/plugins/sap-btp-service-manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-service-manager",
   "description": "This skill provides comprehensive knowledge for SAP Service Manager on SAP Business Technology Platform (BTP). It should be used when managing service instances, bindings, brokers, and platforms across Cloud Foundry, Kyma, Kubernetes, and other environments. Use when provisioning services via SMCTL CLI, BTP CLI, or REST APIs, configuring OAuth2 authentication, working with the SAP BTP Service Operator in Kubernetes, troubleshooting service consumption issues, or implementing cross-environment service management. Keywords: SAP Service Manager, BTP, service instances, service bindings, SMCTL, service broker, OSBAPI, Cloud Foundry, Kyma, Kubernetes, service-manager, service-operator-access, subaccount-admin, OAuth2, X.509, service marketplace, service plans, rate limiting, cf create-service, btp create services/instance, ServiceInstance CRD, ServiceBinding CRD",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-btp-service-manager/skills/sap-btp-service-manager/SKILL.md
+++ b/plugins/sap-btp-service-manager/skills/sap-btp-service-manager/SKILL.md
@@ -6,7 +6,7 @@ description: |
   Keywords: SAP Service Manager, BTP, service instances, service bindings, SMCTL, service broker, OSBAPI, Cloud Foundry, Kyma, Kubernetes, service-manager, service-operator-access, subaccount-admin, OAuth2, X.509, service marketplace, service plans, rate limiting, cf create-service, btp create services/instance, ServiceInstance CRD, ServiceBinding CRD
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2025-11-27
   documentation_source: "https://github.com/SAP-docs/sap-btp-service-manager"
   documentation_files_analyzed: 80+

--- a/plugins/sap-cap-capire/.claude-plugin/plugin.json
+++ b/plugins/sap-cap-capire/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-cap-capire",
   "description": "SAP Cloud Application Programming Model (CAP) development skill using Capire documentation. Use when: building CAP applications, defining CDS models, implementing services, working with SAP HANA/SQLite/PostgreSQL databases, deploying to SAP BTP Cloud Foundry or Kyma, implementing Fiori UIs, handling authorization, multitenancy, or messaging. Covers CDL/CQL/CSN syntax, Node.js and Java runtimes, event handlers, OData services, and CAP plugins.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-cap-capire/skills/sap-cap-capire/SKILL.md
+++ b/plugins/sap-cap-capire/skills/sap-cap-capire/SKILL.md
@@ -8,7 +8,7 @@ description: |
   Node.js and Java runtimes, event handlers, OData services, and CAP plugins.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-02-22"
   cap_version: "@sap/cds 9.7.x"
   mcp_version: "@cap-js/mcp-server 0.0.5"

--- a/plugins/sap-cloud-sdk-ai-python/.claude-plugin/plugin.json
+++ b/plugins/sap-cloud-sdk-ai-python/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-cloud-sdk-ai-python",
   "description": "Integrates the SAP Cloud SDK for AI for Python (sap-ai-sdk-gen, formerly generative-ai-hub-sdk) into Python applications. Use when building Python apps with SAP AI Core, Generative AI Hub, or the Orchestration Service: chat completion, embeddings, streaming, LangChain integration, templating, content filtering, data masking, and document grounding. Supports OpenAI GPT models, Llama, Gemini, Amazon Nova, and other foundation models via SAP BTP.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-cloud-sdk-ai-python/skills/sap-cloud-sdk-ai-python/SKILL.md
+++ b/plugins/sap-cloud-sdk-ai-python/skills/sap-cloud-sdk-ai-python/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Integrates the SAP Cloud SDK for AI for Python (sap-ai-sdk-gen, formerly generative-ai-hub-sdk) into Python applications. Use when building Python apps with SAP AI Core, Generative AI Hub, or the Orchestration Service: chat completion, embeddings, streaming, LangChain integration, templating, content filtering, data masking, and document grounding. Supports OpenAI GPT models, Llama, Gemini, Amazon Nova, and other foundation models via SAP BTP.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-06-15"
   sdk_package: "sap-ai-sdk-gen 6.10.0"
   package_evidence: "docs/project/package-evidence/2026-06-15.json"

--- a/plugins/sap-cloud-sdk-ai/.claude-plugin/plugin.json
+++ b/plugins/sap-cloud-sdk-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-cloud-sdk-ai",
   "description": "Integrates SAP Cloud SDK for AI into JavaScript/TypeScript and Java applications. Use when building applications with SAP AI Core, Generative AI Hub, or Orchestration Service. Covers chat completion, embedding, streaming, function calling, content filtering, data masking, document grounding, prompt registry, and LangChain/Spring AI integration. Supports OpenAI GPT-4o, Llama, Gemini, Amazon Nova, and other foundation models via SAP BTP.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-cloud-sdk-ai/skills/sap-cloud-sdk-ai/SKILL.md
+++ b/plugins/sap-cloud-sdk-ai/skills/sap-cloud-sdk-ai/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Integrates SAP Cloud SDK for AI into JavaScript/TypeScript and Java applications. Use when building applications with SAP AI Core, Generative AI Hub, or Orchestration Service. Covers chat completion, embedding, streaming, function calling, content filtering, data masking, document grounding, prompt registry, and LangChain/Spring AI integration. Supports OpenAI GPT-4o, Llama, Gemini, Amazon Nova, and other foundation models via SAP BTP.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-06-15"
   package_evidence: "docs/project/package-evidence/2026-06-15.json"
 ---

--- a/plugins/sap-datasphere/.claude-plugin/plugin.json
+++ b/plugins/sap-datasphere/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-datasphere",
   "description": "SAP Datasphere development skill with 3 specialized agents, 5 slash commands, and validation hooks. Use when building data warehouses on SAP BTP, creating analytic models, configuring data flows and replication flows, setting up connections, managing spaces and users, implementing data access controls, or using the datasphere CLI. Covers Data Builder, Business Builder, analytic models, 40+ connection types, real-time replication, task chains, content transport, and data marketplace.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-datasphere/skills/sap-datasphere/SKILL.md
+++ b/plugins/sap-datasphere/skills/sap-datasphere/SKILL.md
@@ -3,7 +3,7 @@ name: sap-datasphere
 description: "SAP Datasphere development skill with 3 specialized agents, 5 slash commands, and validation hooks. Use when building data warehouses on SAP BTP, creating analytic models, configuring data flows and replication flows, setting up connections, managing spaces and users, implementing data access controls, or using the datasphere CLI. Covers Data Builder, Business Builder, analytic models, 40+ connection types, real-time replication, task chains, content transport, and data marketplace."
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2026-06-11
   keywords: [sap datasphere, data warehouse cloud, dwc, data builder, business builder, analytic model, graphical view, sql view, transformation flow, replication flow, data flow, task chain, remote table, local table, datasphere connection, datasphere space, data access control, elastic compute node, datasphere cli, data products, data marketplace, catalog, governance, business data cloud, bdc, sap databricks]
 ---

--- a/plugins/sap-dependency-security/.claude-plugin/plugin.json
+++ b/plugins/sap-dependency-security/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-dependency-security",
   "description": "SAP dependency security and MCP executable trust policy with secure upgrades, cooldowns, staged rollout, and supply-chain protection. Use when upgrading deps, configuring security policies, preventing supply chain attacks, pinning SAP MCP servers, or reviewing SAP CAP/UI5/Fiori/HANA/Datasphere/SAC/BTP/ABAP dependency workflows.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-dependency-security/skills/sap-dependency-security/SKILL.md
+++ b/plugins/sap-dependency-security/skills/sap-dependency-security/SKILL.md
@@ -3,7 +3,7 @@ name: sap-dependency-security
 description: "SAP dependency security and MCP executable trust policy with secure upgrades, cooldowns, staged rollout, and supply-chain protection. Use when upgrading deps, configuring security policies, preventing supply chain attacks, pinning SAP MCP servers, or reviewing SAP CAP/UI5/Fiori/HANA/Datasphere/SAC/BTP/ABAP dependency workflows."
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-06-14"
   known_issues: []
 ---

--- a/plugins/sap-fiori-tools/.claude-plugin/plugin.json
+++ b/plugins/sap-fiori-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-fiori-tools",
   "description": "Develops SAP Fiori applications using SAP Fiori tools extensions for VS Code and SAP Business Application Studio. Use when: generating Fiori Elements or Freestyle SAPUI5 applications, configuring Page Editor for List Report or Object Page, working with annotations and Service Modeler, setting up deployment to ABAP or Cloud Foundry, creating adaptation projects, using Guided Development, previewing with mock data or live data, configuring SAP Fiori launchpad, or using AI-powered generation with Project Accelerator/Joule. Technologies: SAP Fiori Elements, SAPUI5, OData V2/V4, CAP, SAP BTP, ABAP, Cloud Foundry, fiori-mcp-server (MCP tools for AI-assisted generation).",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-fiori-tools/skills/sap-fiori-tools/SKILL.md
+++ b/plugins/sap-fiori-tools/skills/sap-fiori-tools/SKILL.md
@@ -9,7 +9,7 @@ description: |
   Technologies: SAP Fiori Elements, SAPUI5, OData V2/V4, CAP, SAP BTP, ABAP, Cloud Foundry, fiori-mcp-server (MCP tools for AI-assisted generation).
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-02-26"
 ---
 

--- a/plugins/sap-hana-cli/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-hana-cli",
   "description": "Assists with SAP HANA Developer CLI (hana-cli) for database development and administration. Use when: installing hana-cli, connecting to SAP HANA databases, inspecting database objects (tables, views, procedures, functions), managing HDI containers, executing SQL queries, converting metadata to CDS/EDMX/OpenAPI formats, managing SAP HANA Cloud instances, working with BTP CLI integration, or troubleshooting hana-cli commands. Covers: 91 commands, 17+ output formats, HDI container management, cloud operations.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-hana-cli/skills/sap-hana-cli/SKILL.md
+++ b/plugins/sap-hana-cli/skills/sap-hana-cli/SKILL.md
@@ -9,7 +9,7 @@ description: |
   Covers: 91 commands, 17+ output formats, HDI container management, cloud operations.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-26"
 ---
 

--- a/plugins/sap-hana-cloud-data-intelligence/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-cloud-data-intelligence/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-hana-cloud-data-intelligence",
   "description": "Develops data processing pipelines, integrations, and machine learning scenarios in SAP Data Intelligence Cloud. Use when building graphs/pipelines with operators, integrating ABAP/S4HANA systems, creating replication flows, developing ML scenarios with JupyterLab, or using Data Transformation Language functions. Covers Gen1/Gen2 operators, subengines (Python, Node.js, C++), structured data operators, and repository objects.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-hana-cloud-data-intelligence/skills/sap-hana-cloud-data-intelligence/SKILL.md
+++ b/plugins/sap-hana-cloud-data-intelligence/skills/sap-hana-cloud-data-intelligence/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Develops data processing pipelines, integrations, and machine learning scenarios in SAP Data Intelligence Cloud. Use when building graphs/pipelines with operators, integrating ABAP/S4HANA systems, creating replication flows, developing ML scenarios with JupyterLab, or using Data Transformation Language functions. Covers Gen1/Gen2 operators, subengines (Python, Node.js, C++), structured data operators, and repository objects.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2025-11-27"
   evidence_status: "stale_docs_only_pending_refresh"
 ---

--- a/plugins/sap-hana-ml/.claude-plugin/plugin.json
+++ b/plugins/sap-hana-ml/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-hana-ml",
   "description": "SAP HANA Machine Learning Python Client (hana-ml) development skill. Use when: Building ML solutions with SAP HANA's in-database machine learning using Python hana-ml library for PAL/APL algorithms, DataFrame operations, AutoML, model persistence, and visualization. Keywords: hana-ml, SAP HANA, machine learning, PAL, APL, predictive analytics, HANA DataFrame, ConnectionContext, classification, regression, clustering, time series, ARIMA, gradient boosting, AutoML, SHAP, model storage",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-hana-ml/skills/sap-hana-ml/SKILL.md
+++ b/plugins/sap-hana-ml/skills/sap-hana-ml/SKILL.md
@@ -12,7 +12,7 @@ description: |
   time series, ARIMA, gradient boosting, AutoML, SHAP, model storage
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2025-11-27
   package_version: 2.22.241011
 ---

--- a/plugins/sap-rpt1/.claude-plugin/plugin.json
+++ b/plugins/sap-rpt1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-rpt1",
   "description": "SAP-RPT-1-OSS local tabular prediction workflows for FI/CO prototype datasets. Use when preparing SAP finance CSV exports for classification or regression experiments with source-verified setup, leakage checks, and governance review.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-rpt1/skills/sap-rpt1/SKILL.md
+++ b/plugins/sap-rpt1/skills/sap-rpt1/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
   - Read
   - Bash
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   model_source: "SAP/sap-rpt-1-oss"
   python_version: "3.11"
   last_verified: "2026-06-18"

--- a/plugins/sap-sac-custom-widget/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-custom-widget/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-sac-custom-widget",
   "description": "SAP Analytics Cloud (SAC) Custom Widget development. Use when building custom visualizations, extending SAC with Web Components, or creating Widget Add-Ons. Covers JSON metadata, JavaScript Web Components, lifecycle functions, data binding with feeds, styling/builder panels, property/event/method definitions, third-party library integration, hosting, security, performance, and debugging. Includes Widget Add-On feature (QRC Q4 2023+) and templates for widgets, charts, and KPI cards.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
@@ -4,7 +4,7 @@ description: "SAP Analytics Cloud (SAC) Custom Widget development. Use when buil
 
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2026-06-12
   sac_version: "2026.8"
   errors_prevented: 25+

--- a/plugins/sap-sac-planning/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-sac-planning",
   "description": "SAP Analytics Cloud (SAC) planning guidance for planning models, planning-enabled stories, data actions, multi actions, version management, data locking, calendar/input workflows, allocations, value driver trees, BPC live planning, and Seamless Planning with SAP Datasphere. Use this for planning design, planning APIs, data action debugging, and planning performance reviews; use sap-sac-scripting for non-planning SAC scripts and sap-datasphere for Datasphere modeling.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-sac-planning/skills/sap-sac-planning/SKILL.md
+++ b/plugins/sap-sac-planning/skills/sap-sac-planning/SKILL.md
@@ -4,7 +4,7 @@ description: |
   SAP Analytics Cloud (SAC) planning guidance for planning models, planning-enabled stories, data actions, multi actions, version management, data locking, calendar/input workflows, allocations, value driver trees, BPC live planning, and Seamless Planning with SAP Datasphere. Use this for planning design, planning APIs, data action debugging, and planning performance reviews; use sap-sac-scripting for non-planning SAC scripts and sap-datasphere for Datasphere modeling.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2026-06-11
   sac_version: "2026.8"
   documentation_source: "https://help.sap.com/docs/SAP_ANALYTICS_CLOUD/00f68c2e08b941f081002fd3691d86a7"

--- a/plugins/sap-sac-scripting/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-scripting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-sac-scripting",
   "description": "Comprehensive SAC scripting skill for SAP Analytics Cloud Analytics Designer and Optimized Story Experience. This skill should be used when the user asks to \"create SAC script\", \"debug Analytics Designer\", \"optimize SAC performance\", \"planning operations in SAC\", \"filter data in SAC\", \"use DataSource API\", \"chart scripting\", \"table manipulation\", \"SAC event handlers\", \"version management\", \"data locking\", \"Optimized Story Experience API\", \"OSE scripting\", \"OSE widget API\", \"OSE DataSource\", \"story scripting API\", \"OSE planning API\", \"OSE method\", \"optimized story\", \"SAC story scripting\", \"story script\", \"SAC scripting\", or works with SAC widgets, planning models, or analytics applications.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-sac-scripting/skills/sap-sac-scripting/SKILL.md
+++ b/plugins/sap-sac-scripting/skills/sap-sac-scripting/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Comprehensive SAC scripting skill for SAP Analytics Cloud Analytics Designer and Optimized Story Experience. This skill should be used when the user asks to "create SAC script", "debug Analytics Designer", "optimize SAC performance", "planning operations in SAC", "filter data in SAC", "use DataSource API", "chart scripting", "table manipulation", "SAC event handlers", "version management", "data locking", "Optimized Story Experience API", "OSE scripting", "OSE widget API", "OSE DataSource", "story scripting API", "OSE planning API", "OSE method", "optimized story", "SAC story scripting", "story script", "SAC scripting", or works with SAC widgets, planning models, or analytics applications.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2026-06-11
   sac_version: "Q2 2026 (2026.8)"
   api_reference_version: "2025.20 (OSE Q2 2026)"

--- a/plugins/sap-sac-test-automation/.claude-plugin/plugin.json
+++ b/plugins/sap-sac-test-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-sac-test-automation",
   "description": "SAP Analytics Cloud (SAC) automated testing skill for designing capability-gated browser discovery and deterministic Playwright test suites for SAC stories, dashboards, reports, planning workflows, comments, permissions, visual regression, and reusable QA automation. This skill should be used when building SAC end-to-end tests, onboarding SAC dashboards into Playwright, creating dashboard profiles or scenario YAML, using Microsoft Edge/CDP, Chrome DevTools MCP, Vercel Labs agent-browser, or manual discovery for SAC components, testing SAC optimized stories, configuring SAC auth storage state, managing visual/data baselines, testing comments, planning writeback, data actions, multi actions, role-based views, restricted Windows/company environments, or creating SAC failure triage artifacts.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-sac-test-automation/skills/sap-sac-test-automation/SKILL.md
+++ b/plugins/sap-sac-test-automation/skills/sap-sac-test-automation/SKILL.md
@@ -4,7 +4,7 @@ description: |
   SAP Analytics Cloud (SAC) automated testing skill for designing capability-gated browser discovery and deterministic Playwright test suites for SAC stories, dashboards, reports, planning workflows, comments, permissions, visual regression, and reusable QA automation. This skill should be used when building SAC end-to-end tests, onboarding SAC dashboards into Playwright, creating dashboard profiles or scenario YAML, using Microsoft Edge/CDP, Chrome DevTools MCP, Vercel Labs agent-browser, or manual discovery for SAC components, testing SAC optimized stories, configuring SAC auth storage state, managing visual/data baselines, testing comments, planning writeback, data actions, multi actions, role-based views, restricted Windows/company environments, or creating SAC failure triage artifacts.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2026-06-17
   sac_version: "2026.8"
   documentation_source: "docs/project/sac-test-automation-source-review-2026-06-17.md"

--- a/plugins/sap-sqlscript/.claude-plugin/plugin.json
+++ b/plugins/sap-sqlscript/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-sqlscript",
   "description": "This skill should be used when the user asks to \"write a SQLScript procedure\", \"create HANA stored procedure\", \"implement AMDP method\", \"optimize SQLScript performance\", \"handle SQLScript exceptions\", \"debug HANA procedure\", \"create table function\", or mentions SQLScript, SAP HANA procedures, AMDP, EXIT HANDLER, or code-to-data paradigm. Comprehensive SQLScript development guidance for SAP HANA database programming including syntax patterns, built-in functions, exception handling, performance optimization, cursor management, and ABAP Managed Database Procedure (AMDP) integration.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sap-sqlscript/skills/sap-sqlscript/SKILL.md
+++ b/plugins/sap-sqlscript/skills/sap-sqlscript/SKILL.md
@@ -6,7 +6,7 @@ description: |
   Comprehensive SQLScript development guidance for SAP HANA database programming including syntax patterns, built-in functions, exception handling, performance optimization, cursor management, and ABAP Managed Database Procedure (AMDP) integration.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-05-31"
   production_tested: "No; documentation and community references only, no live HANA runtime evidence"
   sap_hana_version: "2.0 SPS08"

--- a/plugins/sapui5-cli/.claude-plugin/plugin.json
+++ b/plugins/sapui5-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sapui5-cli",
   "description": "Manages SAPUI5/OpenUI5 projects using the UI5 Tooling CLI (@ui5/cli). Use when initializing UI5 projects, configuring ui5.yaml or ui5-workspace.yaml files, building UI5 applications or libraries, running development servers with HTTP/2 support, creating custom build tasks or server middleware, managing workspace/monorepo setups, troubleshooting UI5 CLI errors, migrating between UI5 CLI versions, or optimizing build performance. Supports both OpenUI5 and SAPUI5 frameworks with complete configuration and extensibility guidance.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sapui5-cli/skills/sapui5-cli/SKILL.md
+++ b/plugins/sapui5-cli/skills/sapui5-cli/SKILL.md
@@ -3,7 +3,7 @@ name: sapui5-cli
 description: Manages SAPUI5/OpenUI5 projects using the UI5 Tooling CLI (@ui5/cli). Use when initializing UI5 projects, configuring ui5.yaml or ui5-workspace.yaml files, building UI5 applications or libraries, running development servers with HTTP/2 support, creating custom build tasks or server middleware, managing workspace/monorepo setups, troubleshooting UI5 CLI errors, migrating between UI5 CLI versions, or optimizing build performance. Supports both OpenUI5 and SAPUI5 frameworks with complete configuration and extensibility guidance.
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   ui5_cli_version: "4.0.55"
   last_verified: "2026-05-31"
   official_docs: "https://ui5.github.io/cli/stable/"

--- a/plugins/sapui5-linter/.claude-plugin/plugin.json
+++ b/plugins/sapui5-linter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sapui5-linter",
   "description": "Use this skill when working with the UI5 Linter (@ui5/linter) for static code analysis of SAPUI5/OpenUI5 applications and libraries. Covers setup, configuring linting rules, running the linter to detect deprecated APIs, global variable usage, CSP violations, and manifest issues. Supports autofix for deprecated API usage, global references, event handlers, and manifest properties. Includes CI/CD integration, pre-commit hooks, and UI5 2.x migration preparation.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sapui5-linter/skills/sapui5-linter/SKILL.md
+++ b/plugins/sapui5-linter/skills/sapui5-linter/SKILL.md
@@ -3,7 +3,7 @@ name: sapui5-linter
 description: "Use this skill when working with the UI5 Linter (@ui5/linter) for static code analysis of SAPUI5/OpenUI5 applications and libraries. Covers setup, configuring linting rules, running the linter to detect deprecated APIs, global variable usage, CSP violations, and manifest issues. Supports autofix for deprecated API usage, global references, event handlers, and manifest properties. Includes CI/CD integration, pre-commit hooks, and UI5 2.x migration preparation."
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: "2026-06-14"
   ui5_linter_version: "1.22.0"
   source: "https://github.com/UI5/linter"
@@ -338,6 +338,6 @@ ui5lint --perf
 
 ---
 
-**Last Updated**: 2026-06-14 | **Version**: 2.3.0
+**Last Updated**: 2026-06-14 | **Version**: 2.3.1
 **Previous Restructure Version**: 1.0.1 | **Lines Reduced**: 376 (from 827)
 **Next Review**: 2026-02-25

--- a/plugins/sapui5/.claude-plugin/plugin.json
+++ b/plugins/sapui5/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sapui5",
   "description": "This skill should be used when developing SAP UI5 applications, including creating freestyle apps, Fiori Elements apps, custom controls, testing, data binding, OData integration, routing, and troubleshooting. Use when building enterprise web applications with SAP UI5 framework, implementing MVC patterns, configuring manifest.json, creating XML views, writing controllers, setting up data models (JSON, OData v2/v4), implementing responsive UI with sap.m controls, building Fiori Elements apps, writing unit tests with QUnit, integration tests with OPA5, setting up mock servers, handling security (XSS, CSP), optimizing performance, implementing accessibility features, or debugging UI5 applications. Also covers sap.ui.mdc controls and TypeScript control libraries.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "E.J."
   },

--- a/plugins/sapui5/skills/sapui5/SKILL.md
+++ b/plugins/sapui5/skills/sapui5/SKILL.md
@@ -3,7 +3,7 @@ name: sapui5
 description: "This skill should be used when developing SAP UI5 applications, including creating freestyle apps, Fiori Elements apps, custom controls, testing, data binding, OData integration, routing, and troubleshooting. Use when building enterprise web applications with SAP UI5 framework, implementing MVC patterns, configuring manifest.json, creating XML views, writing controllers, setting up data models (JSON, OData v2/v4), implementing responsive UI with sap.m controls, building Fiori Elements apps, writing unit tests with QUnit, integration tests with OPA5, setting up mock servers, handling security (XSS, CSP), optimizing performance, implementing accessibility features, or debugging UI5 applications. Also covers sap.ui.mdc controls and TypeScript control libraries."
 license: GPL-3.0
 metadata:
-  version: "2.3.0"
+  version: "2.3.1"
   last_verified: 2026-05-31
   framework_version: "1.148.1 latest verified, 1.120.0+ baseline"
   documentation_source: "https://github.com/SAP-docs/sapui5"

--- a/scripts/validate-skill-quality.mjs
+++ b/scripts/validate-skill-quality.mjs
@@ -15,7 +15,7 @@ const repoRoot = repoRootFrom(import.meta.url);
 const pluginsRoot = path.join(repoRoot, "plugins");
 const auditReport = path.join(repoRoot, "docs/project/plugin-skills-audit-2026-06-14.md");
 const ledgerPath = path.join(repoRoot, "docs/project/source-verification-ledger.json");
-const expectedVersion = "2.3.0";
+const expectedVersion = "2.3.1";
 const staleAfterDays = 90;
 const allowedSkillRootEntries = new Set([
   "SKILL.md",


### PR DESCRIPTION
## Summary

- bump the coordinated SAP Skills release version to `2.3.1`
- regenerate the marketplace and all 37 root plugin manifests
- update all 37 `SKILL.md` frontmatter versions and the skill-quality validator contract
- refresh README, changelog, and current-state marketplace docs for the 37-plugin inventory

## Validation

- `./scripts/validate-inventory.sh`
- `./scripts/validate-manifest-drift.mjs`
- `npm run validate:marketplace`
- `npm run validate:skill-quality`
- `npm run validate`

Notes: validation passes. Existing warning-style follow-ups remain for stale verification/provenance/trigger precision, but all checks exit successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.3.1 across all marketplace plugins and documentation.

* **Documentation**
  * Updated release notes and marketplace infrastructure documentation.
  * Marketplace now includes 37 available plugins (updated from 35).
  * Refreshed all plugin metadata and resource references to reflect new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->