### PR TITLE
feat: add local SAC custom widget builder guidance

### DIFF
--- a/plugins/sap-sac-custom-widget/commands/widget-generate.md
+++ b/plugins/sap-sac-custom-widget/commands/widget-generate.md
@@ -15,12 +15,12 @@ argument-hint: [widget-name]
 
 ## Output Contract
 
-Return data-aware suggestions, the planned widget structure, file snippets or files to create/change, security/accessibility notes, and confirmation points before writes. Default to snippets/plans; generate files only when the user explicitly requests generation and confirms a target directory.
+Return data-aware suggestions, the planned widget structure, SAP sample lesson fit, file snippets or files to create/change, local-builder/design-runtime inclusion notes, security/accessibility notes, and confirmation points before writes. Default to snippets/plans; generate files only when the user explicitly requests generation and confirms a target directory.
 
 
 # SAC Custom Widget Generator Command
 
-Interactively create a complete SAP Analytics Cloud custom widget scaffold including widget.json metadata, widget.js Web Component implementation, and a browser design runtime. For prompt-driven requests, use a two-stage flow: suggest 2-3 creative options first, then generate the selected package.
+Interactively create a complete SAP Analytics Cloud custom widget scaffold including widget.json metadata, widget.js Web Component implementation, optional builder/styling panels, the local builder scaffold, and the browser design runtime. For prompt-driven requests, use a two-stage flow: suggest 2-3 creative options first, then generate the selected package.
 
 ## Usage
 
@@ -47,6 +47,7 @@ When invoked without `--quick`, ask the user these questions:
 3. **Business Goal and Chart Intent**
    - Decision or insight the widget should support
    - Ask whether to recommend chart types or use a fixed chart type
+   - Consult `references/sap-sample-widget-lessons.md` when the request resembles a chart, KPI/gauge, flow/hierarchy, input utility, Widget Add-On, or build-based app
 
 4. **Sample Data or Schema**
    - Columns, dimensions, measures, dates, versions, and filters
@@ -61,24 +62,30 @@ When invoked without `--quick`, ask the user these questions:
    - "Which components do you need?"
    - Options: Main only, Main + Styling Panel, Main + Builder Panel, All three
 
+7. **Local Builder**
+   - "Include the local SAC widget builder scaffold?"
+   - Default: Yes for local or enterprise environments
+   - Copy `templates/local-builder/` into generated packages when the user wants a no-install browser builder for metadata, properties, feeds, methods, events, and SAC artifact export
+   - Mention that the local builder includes generic sample-informed pattern hints but does not copy SAP sample code or assets
+
 ### Optional Questions
 
-7. **Third-Party Library**
+8. **Third-Party Library**
    - "Will you integrate a charting library?"
    - Options: ECharts, D3.js, Chart.js, None
 
-8. **Brand and Visual Direction**
+9. **Brand and Visual Direction**
    - Brand logo/icon URLs, colors, and style preference
    - Use brand assets only when they are trusted and accessible to SAC
    - If provided, map icon URL to manifest `icon` and logo URL to a `brandLogoUrl` property
 
-9. **Deployment and Reuse Target**
+10. **Deployment and Reuse Target**
    - SAC-hosted files, external HTTPS host, or widget server
    - SAC ZIP resource upload, if the tenant flow requires uploading a ZIP after `widget.json`
    - Confirm this before deciding whether CSS/HTML can be separate resource files or must be embedded in JavaScript templates
    - Ask whether the widget should be reusable inside an SAC composite
 
-10. **Initial Properties**
+11. **Initial Properties**
    - "What properties should be configurable?"
    - Default: title (string), color (Color)
 
@@ -150,6 +157,7 @@ If the consuming flow requires text sections, use these exact markers:
 ## AI Generation Compatibility Rules
 
 - Use Web Components with Shadow DOM and IIFE-wrapped JavaScript.
+- Use `references/sap-sample-widget-lessons.md` as a structure and caveat reference before choosing a sample-like scaffold. Keep generated code original.
 - Use naming conventions: widget folder/name `hyphen-case`, manifest ID `com.company.widgetname`, tag `com-company-widgetname`, class `PascalCase`, `newInstancePrefix` `PascalCase` letters only.
 - Define the HTML/CSS shell with `document.createElement("template")`; static `template.innerHTML` is allowed for the component template.
 - Keep generated styling scoped to the Web Component or Shadow DOM boundary. Do not rely on SAC story theme CSS, SAP shell class names, or global story CSS to style widget internals.
@@ -220,6 +228,30 @@ No-build browser preview scaffold with:
 - `runtime.js` - SAC custom-widget mock runtime, controls, and export logic
 - `design-runtime.json` - Sidecar config for widgets, scenarios, data, viewport, theme, and design tokens
 
+### 5. local-builder/ (Recommended for Local Enterprise Generation)
+
+Static no-install builder scaffold with:
+- `index.html` - Local builder UI for metadata, component selection, properties, feeds, methods, events, and export actions
+- `builder.css` - Local-only builder styling
+- `builder.js` - Vanilla JavaScript generator and in-browser Resource-ZIP writer
+- `builder-config.json` - Defaults, control palette, and SAC export contract
+- `server.mjs` - Node loopback fallback when direct file access is blocked
+
+The local builder is for scaffold generation and SAC artifact export. It is not a live SAC runtime and does not replace `design-runtime/` preview checks.
+
+### 6. sample-informed pattern hints
+
+When the request maps to a SAP sample family, document the chosen hint and caveat:
+
+- `data-bound-chart` for line, funnel, pie, nested pie, Pareto, and bar-gradient-like widgets
+- `kpi-gauge` for KPI ring, gauge grade, half donut, and compact score displays
+- `flow-hierarchy-chart` for Sankey, Sunburst, Tree, and hierarchy/flow widgets
+- `builder-input-utility` for word-cloud/input widgets and authored text utilities
+- Widget Add-ons use `references/widget-addon-guide.md` and the `extensions[]` manifest model
+- Build-based file upload, UI5, React, or API/service widgets require explicit dependency, security, tenant, and packaging planning
+
+Do not copy SAP sample runtime code, assets, dependency bundles, tenant URLs, or third-party libraries into generated packages.
+
 ## Output Structure
 
 ```
@@ -228,12 +260,30 @@ widget-name/
 ├── widget.js
 ├── styling-panel.js    (if selected)
 ├── builder-panel.js    (if selected)
+├── local-builder/      (recommended for local/enterprise generation)
+│   ├── index.html
+│   ├── builder.css
+│   ├── builder.js
+│   ├── builder-config.json
+│   └── server.mjs
 └── design-runtime/
     ├── index.html
     ├── runtime.css
     ├── runtime.js
     └── design-runtime.json
 ```
+
+## Local Custom Widget Builder
+
+Offer `templates/local-builder/` as the default local enterprise option when a user wants a browser builder similar in spirit to hosted SAC widget builder tools but must stay local. It must remain dependency-free and local-only:
+
+- Do not use public CDNs, remote scripts, external npm packages, tenant URLs, or credentials.
+- Keep primary export as two SAC upload artifacts: `widget.json` and `<slug>-resources.zip`.
+- Keep Resource-ZIP entries root-level and limited to component JavaScript plus optional image assets.
+- Exclude `widget.json`, `local-builder/`, `design-runtime/`, `.html`, `.css`, `.md`, `.json`, tests, and docs from Resource-ZIP output.
+- Use `node server.mjs` from `local-builder/` only as a loopback fallback if direct `file://` use is blocked.
+- Treat local builder output as generated scaffolding; still validate with `/widget-validate`, JavaScript syntax checks, Resource-ZIP inspection, and SAC tenant import when available.
+- Use the built-in sample-informed pattern hints only as generic prefill. Reference-only hints for Widget Add-ons and build-based apps should redirect to planning guidance rather than generating unsupported scaffolds.
 
 ## Browser Design Runtime
 
@@ -453,6 +503,8 @@ After files are generated, provide:
    - How to add to SAC
    - How to set up hosting
    - How to generate integrity hash
+   - How to open `local-builder/index.html` directly for local scaffold edits and SAC two-file export
+   - Optional local builder server fallback from `local-builder/`: `node server.mjs`
    - How to open `design-runtime/index.html` directly
    - Optional static server fallback from the widget package root:
      - macOS/Linux: `python3 -m http.server 8000`
@@ -469,6 +521,7 @@ After files are generated, provide:
    - Where to add visualization logic
    - How to add more properties
    - How to implement events
+   - How to use the local builder control palette to add text, number, hex color string, toggle, dropdown, textarea, slider, group, and divider controls
    - How to use exported `agent-iteration.json` and Markdown notes for the next agent iteration
 
 4. **Ready for SAC Install**
@@ -497,8 +550,10 @@ When this command is invoked:
 4. Generate widget.json with all selections
 5. Generate widget.js with matching implementation
 6. Generate additional component files if selected
-7. Copy `templates/design-runtime/` into the generated package and populate its sidecar config for the generated widget
-8. Verify naming, data binding order, sequential result indices, generated-code compatibility rules, and runtime sidecar paths that use browser URL `/` separators
-9. If and only if the user confirmed a target directory, write files there; otherwise return snippets and the proposed file tree, including `design-runtime/`
-10. Provide post-generation instructions, including the Ready for SAC Install and Composite Readiness blocks
-11. Suggest running `/widget-validate` and opening `design-runtime/index.html` to verify
+7. Use `references/sap-sample-widget-lessons.md` to identify the nearest sample family, required caveats, and whether the request should stay on the normal custom-widget path, route to Widget Add-on guidance, or require build-based app planning
+8. Copy `templates/local-builder/` into the generated package by default for local/enterprise generation, unless the user explicitly declines it
+9. Copy `templates/design-runtime/` into the generated package and populate its sidecar config for the generated widget
+10. Verify naming, data binding order, sequential result indices, generated-code compatibility rules, local builder export naming, Resource-ZIP exclusions, sample-informed caveats, and runtime sidecar paths that use browser URL `/` separators
+11. If and only if the user confirmed a target directory, write files there; otherwise return snippets and the proposed file tree, including `local-builder/` and `design-runtime/`
+12. Provide post-generation instructions, including the local builder, sample lesson caveats, Ready for SAC Install, and Composite Readiness blocks
+13. Suggest running `/widget-validate`, opening `local-builder/index.html` for scaffold/export edits, and opening `design-runtime/index.html` for preview verification

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/README.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/README.md
@@ -29,7 +29,7 @@ Portable, documentation-audited plugin content for developing custom widgets in 
 | Command | Usage | Description |
 |---------|-------|-------------|
 | `/widget-validate` | `/widget-validate [file]` | Validate widget.json schema and widget.js structure |
-| `/widget-generate` | `/widget-generate` | Interactively generate widget scaffold with JSON, JS, and browser design runtime |
+| `/widget-generate` | `/widget-generate` | Interactively generate widget scaffold with JSON, JS, local builder, sample-informed hints, and browser design runtime |
 | `/widget-lint` | `/widget-lint [file]` | Performance, security, and best practices analysis |
 
 ### Templates
@@ -41,6 +41,8 @@ Docs-audited scaffolds in `templates/` directory:
 | `basic-widget.js` | Minimal Web Component with all lifecycle functions |
 | `data-bound-chart.js` | ECharts widget with SAC data binding |
 | `styling-panel.js` | Runtime customization panel |
+| `builder-panel.js` | Design-time configuration panel |
+| `local-builder/` | No-install local scaffold builder and SAC two-file artifact exporter |
 | `design-runtime/` | No-build browser preview, scenario switching, design controls, and agent iteration export |
 | `widget.json-minimal` | Bare-minimum metadata |
 | `widget.json-complete` | Full-featured metadata with all options |
@@ -83,6 +85,8 @@ Claude activation hooks for quality checks on Write/Edit/MultiEdit operations; o
 This skill should be used when:
 - Creating custom visualizations for SAP Analytics Cloud
 - Previewing generated custom widgets in a non-SAP browser design runtime before SAC import
+- Generating widget scaffolds locally with no public CDN, no npm install, and no remote builder service
+- Choosing sample-informed starting points for data-bound charts, KPI/gauge widgets, hierarchy/flow charts, input utilities, add-ons, or build-based apps
 - Building interactive components for SAC stories
 - Integrating third-party charting libraries (ECharts, D3.js, Chart.js)
 - Implementing custom input controls for Analytics Designer
@@ -107,6 +111,8 @@ This skill should be used when:
 - Data binding configuration and usage
 - Styling and builder panel implementation
 - CSS and styling compliance guidance for Shadow DOM, story-theme boundaries, and SAC ZIP resource packages
+- Local custom widget builder for metadata, properties, feeds, methods, events, and SAC two-file export
+- SAP sample-widget lessons for generation defaults, Data Binding/OVM caveats, Resource-ZIP path rules, panel separation, add-on routing, and build-based app boundaries
 - Browser design runtime for local preview, multi-widget comparison, design-token tuning, and agent iteration export
 - Multiple hosting options (SAC-hosted, GitHub, external)
 - Security best practices (integrity hash, CORS)
@@ -129,7 +135,7 @@ This skill should be used when:
 | Errors Prevented | 25+ |
 | Agents | 3 |
 | Commands | 3 |
-| Templates | 6 |
+| Templates | 8 plus local builder scaffold |
 
 ## Official Documentation
 
@@ -142,6 +148,8 @@ This skill should be used when:
 
 - [SAP Samples - Custom Widgets](https://github.com/SAP-samples/analytics-cloud-datasphere-community-content/tree/main/SAC_Custom_Widgets)
 - [SAP Custom Widget GitHub](https://github.com/SAP-Custom-Widget)
+
+Use `references/sap-sample-widget-lessons.md` before generation when the requested widget resembles these samples. The reference covers all 17 sample folders and keeps the samples as lessons, not copied template code.
 
 ## Community Resources
 

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/README.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/README.md
@@ -117,7 +117,7 @@ This skill should be used when:
 - Multiple hosting options (SAC-hosted, GitHub, external)
 - Security best practices (integrity hash, CORS)
 - Common error solutions and debugging techniques
-- 6 ready-to-use widget templates
+- 8 ready-to-use widget templates
 - ECharts integration guide
 - Widget Add-On feature (QRC Q4 2023+)
 - Performance optimization guidelines
@@ -135,7 +135,7 @@ This skill should be used when:
 | Errors Prevented | 25+ |
 | Agents | 3 |
 | Commands | 3 |
-| Templates | 8 plus local builder scaffold |
+| Templates | 8 |
 
 ## Official Documentation
 

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
@@ -34,6 +34,8 @@ allowed-tools:
 ## Table of Contents
 - [Overview](#overview)
 - [AI-Assisted Generation](#ai-assisted-generation)
+- [Local Custom Widget Builder](#local-custom-widget-builder)
+- [SAP Sample Widget Lessons](#sap-sample-widget-lessons)
 - [Browser Design Runtime](#browser-design-runtime)
 - [CSS and Styling Compliance](#css-and-styling-compliance)
 - [SAC Import and Packaging](#sac-import-and-packaging)
@@ -72,9 +74,21 @@ For prompt-driven widget creation, first suggest 2-3 data-aware widget options, 
 
 ---
 
+## Local Custom Widget Builder
+
+For enterprise or locked-down local environments, offer **`templates/local-builder/`** as the standard no-install scaffold builder. It runs as static HTML/CSS/vanilla JavaScript, avoids public CDNs and external packages, and exports SAC upload artifacts as two separate downloads: `widget.json` and a Resource-ZIP containing only root-level component JavaScript files. Use Node's `server.mjs` fallback when direct `file://` use is blocked. See **`references/local-builder-workflow.md`** for builder boundaries, export rules, and validation checks.
+
+---
+
+## SAP Sample Widget Lessons
+
+Before generating a chart, KPI, hierarchy, input utility, Widget Add-On, or build-based widget, consult **`references/sap-sample-widget-lessons.md`**. It audits every SAP sample folder and distills reusable lessons for Data Binding-first scaffolds, root-relative Resource-ZIP URLs, styling/builder panel separation, support flags, custom `types`, script methods/events, add-on `extensions[]`, and build-based app caveats. Use the lessons for structure and risk checks only; do not copy SAP sample code or assets into generated packages.
+
+---
+
 ## Browser Design Runtime
 
-Generated widget packages should include **`templates/design-runtime/`** as a no-build, file-first browser preview scaffold. Use it to mock custom-widget essentials outside SAP, adjust properties/design tokens/sample data/viewports, compare multiple widgets, and export an agent iteration payload. See **`references/browser-design-runtime.md`** for runtime boundaries and configuration/export contracts.
+Generated widget packages should include **`templates/design-runtime/`** as a no-build, file-first browser preview scaffold. Use it after generation to mock custom-widget essentials outside SAP, adjust properties/design tokens/sample data/viewports, compare multiple widgets, and export an agent iteration payload. See **`references/browser-design-runtime.md`** for runtime boundaries and configuration/export contracts. Use `templates/local-builder/` for scaffold generation/export; use `templates/design-runtime/` for preview and iteration.
 
 ---
 
@@ -109,7 +123,7 @@ This plugin provides specialized agents, commands, and validation hooks for comp
 | Command | Usage | Description |
 |---------|-------|-------------|
 | `/widget-validate` | `/widget-validate [file]` | Validate widget.json schema and widget.js structure |
-| `/widget-generate` | `/widget-generate` | Interactively generate widget scaffold with JSON, JS, and browser design runtime |
+| `/widget-generate` | `/widget-generate` | Interactively generate widget scaffold with JSON, JS, local builder, and browser design runtime |
 | `/widget-lint` | `/widget-lint [file]` | Performance, security, and best practices analysis |
 
 ### Validation Hooks
@@ -126,6 +140,8 @@ Ready-to-use scaffolds in `templates/` directory:
 - `basic-widget.js` - Minimal Web Component with all lifecycle functions
 - `data-bound-chart.js` - ECharts widget with data binding
 - `styling-panel.js` - Runtime customization panel
+- `builder-panel.js` - Design-time configuration panel
+- `local-builder/` - Static local scaffold builder and SAC artifact exporter
 - `design-runtime/` - Browser preview and design iteration runtime
 - `widget.json-minimal` - Bare-minimum metadata
 - `widget.json-complete` - Full-featured metadata with all options
@@ -244,7 +260,7 @@ A custom widget requires two files:
 
 ## Community Sample Widgets
 
-SAP provides 15+ ready-to-use custom widget samples:
+SAP provides a community sample repository with 17 custom widget sample folders:
 
 **Repository**: [SAP-samples/SAC_Custom_Widgets](https://github.com/SAP-samples/analytics-cloud-datasphere-community-content/tree/main/SAC_Custom_Widgets)
 
@@ -254,9 +270,9 @@ SAP provides 15+ ready-to-use custom widget samples:
 | **KPI/Gauge** | KPI Ring, Gauge Grade, Half Donut, Nested Pie, Custom Pie |
 | **Utilities** | File Upload, Word Cloud, Bar Gradient, Widget Add-on Sample |
 
-**Requirements**: Optimized View Mode (OVM) enabled, data binding support
+**Requirements**: Most samples assume Data Binding and Optimized View Mode (OVM) or Optimized and Unified Story Experience.
 
-**Note**: Check third-party library licenses before production use.
+**Note**: Check third-party library licenses before production use, adjust hosted component paths when moving samples, and treat live SAC import/runtime validation as tenant-specific. See **`references/sap-sample-widget-lessons.md`** for the per-sample audit and creation lessons.
 
 ---
 
@@ -411,6 +427,8 @@ See **`references/widget-addon-guide.md`** for complete implementation.
 - **`templates/basic-widget.js`** - Minimal Web Component scaffold (~60 lines)
 - **`templates/data-bound-chart.js`** - ECharts widget with SAC data binding (~120 lines)
 - **`templates/styling-panel.js`** - Styling panel for runtime customization (~150 lines)
+- **`templates/builder-panel.js`** - Builder panel for design-time configuration
+- **`templates/local-builder/`** - No-install local builder for metadata, feeds, properties, methods, events, and SAC two-file export
 - **`templates/design-runtime/`** - No-build browser preview, design-token controls, scenario switching, and agent iteration export
 - **`templates/widget.json-minimal`** - Bare-minimum metadata (~25 lines)
 - **`templates/widget.json-complete`** - Full-featured metadata (~100 lines)
@@ -426,9 +444,11 @@ See **`references/widget-addon-guide.md`** for complete implementation.
 7. **`references/integration-and-migration.md`** - Script integration, content transport
 8. **`references/script-api-reference.md`** - DataSource, Selection, MemberInfo APIs
 9. **`references/ai-assisted-composite-generation.md`** - Prompt-driven generation, RAG, brand styling, validation, and composite-ready output guidance
-10. **`references/browser-design-runtime.md`** - Non-SAP browser preview runtime, sidecar config, and agent iteration export
-11. **`references/css-and-styling-compliance.md`** - SAP Help-backed CSS, theme, Shadow DOM, and packaging guidance for generated widgets
-12. **`references/sac-import-packaging-lessons.md`** - SAC-hosted Resource-ZIP upload sequence, URL rules, ZIP hygiene, builder/tree state rules, self-contained component checks, final-artifact tests, and SAC error triage
+10. **`references/local-builder-workflow.md`** - Enterprise-safe local builder workflow, export contract, and validation checklist
+11. **`references/sap-sample-widget-lessons.md`** - SAP sample widget audit matrix, reusable generation lessons, and add-on/build-based routing caveats
+12. **`references/browser-design-runtime.md`** - Non-SAP browser preview runtime, sidecar config, and agent iteration export
+13. **`references/css-and-styling-compliance.md`** - SAP Help-backed CSS, theme, Shadow DOM, and packaging guidance for generated widgets
+14. **`references/sac-import-packaging-lessons.md`** - SAC-hosted Resource-ZIP upload sequence, URL rules, ZIP hygiene, builder/tree state rules, self-contained component checks, final-artifact tests, and SAC error triage
 
 ---
 
@@ -446,6 +466,12 @@ See **`references/widget-addon-guide.md`** for complete implementation.
 ---
 
 ## Version History
+
+**Unreleased**
+- Added an enterprise-safe `templates/local-builder/` scaffold for local widget metadata, property/feed configuration, and SAC two-file artifact export
+- Added `templates/builder-panel.js` so builder panel generation has a bundled self-contained template
+- Added local builder validation coverage without advancing `last_verified`; live SAC upload/runtime validation remains pending
+- Added SAP sample-widget lessons and local-builder pattern hints for data-bound charts, KPI/gauge widgets, flow/hierarchy widgets, input utilities, Widget Add-ons, and build-based apps without copying upstream sample code
 
 **v2.3.2** (2026-07-06)
 - Added SAC Resource-ZIP import lessons from the Configurable Menu Navigation project

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/browser-design-runtime.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/browser-design-runtime.md
@@ -5,6 +5,8 @@ Synthetic example:
 
 Use the `templates/design-runtime/` scaffold when a generated widget package should be previewed, tuned, and reviewed outside SAP before SAC import.
 
+Use `templates/local-builder/` instead when the user needs a browser UI to generate or export the initial scaffold. The design runtime starts after code exists; it previews and iterates on generated widgets.
+
 ## Table of Contents
 
 1. [Purpose](#purpose)
@@ -29,6 +31,8 @@ The design runtime gives agents and users a fast browser loop for:
 - Exporting structured feedback for the next agent iteration.
 
 Use it to improve visual quality and catch obvious binding, sizing, empty-state, and styling issues before SAC import.
+
+Do not use the design runtime as the scaffold builder or SAC artifact packager. Use `references/local-builder-workflow.md` for local builder generation and two-file SAC export rules.
 
 ## Runtime Boundary
 

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/local-builder-workflow.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/local-builder-workflow.md
@@ -1,0 +1,141 @@
+# Local Builder Workflow
+
+Use this reference when a user wants a local SAC custom widget builder for enterprise machines, restricted laptops, or offline-first scaffold generation.
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Boundary](#boundary)
+3. [Generated Package Shape](#generated-package-shape)
+4. [Builder Controls](#builder-controls)
+5. [Export Contract](#export-contract)
+6. [Usage Workflow](#usage-workflow)
+7. [Validation Checklist](#validation-checklist)
+8. [Source](#source)
+
+---
+
+## Purpose
+
+`templates/local-builder/` provides a static, no-install browser builder for creating SAC custom widget scaffolds. It is inspired by browser-based widget builders, but keeps all work local and avoids external packages, public CDNs, remote scripts, tenant URLs, credentials, and online services.
+
+Use it when users want to configure widget metadata, properties, feeds, methods, events, builder/styling component choices, and SAC upload artifacts from a browser UI before continuing with code edits.
+
+## Boundary
+
+The local builder creates scaffolds and export artifacts. It does not validate live SAC import, tenant trust, resource permissions, story runtime behavior, or real model binding.
+
+Use:
+
+- `local-builder/` for scaffold generation and `widget.json` plus Resource-ZIP export.
+- `design-runtime/` for local preview, scenario switching, design-token tuning, sample data, and agent iteration export.
+- Real SAC tenant import for final truth.
+
+## Generated Package Shape
+
+Generated packages should include both local tooling folders when the user wants local iteration:
+
+```text
+widget-name/
+├── widget.json
+├── widget.js
+├── builder.js
+├── styling.js
+├── local-builder/
+│   ├── index.html
+│   ├── builder.css
+│   ├── builder.js
+│   ├── builder-config.json
+│   └── server.mjs
+└── design-runtime/
+    ├── index.html
+    ├── runtime.css
+    ├── runtime.js
+    └── design-runtime.json
+```
+
+Do not include `local-builder/` or `design-runtime/` in SAC Resource-ZIP output.
+
+## Builder Controls
+
+The control palette maps local UI controls to portable SAC manifest properties:
+
+| Builder control | SAC property type |
+|-----------------|-------------------|
+| Text input | `string` |
+| Number | `number` |
+| Integer | `integer` |
+| Hex color string | `string` with a hex default |
+| Toggle | `boolean` |
+| Dropdown | `string` |
+| Textarea | `string` |
+| Slider | `integer` |
+| Group label | `string` |
+| Divider | `boolean` |
+
+Prefer hex color strings for portable generated packages. Use SAC `Color` only after the target tenant and exact panel flow accept it.
+
+The Sample Patterns area provides SAP-sample-informed hints for common starting points:
+
+- Data-bound chart
+- KPI / gauge
+- Flow / hierarchy
+- Builder input utility
+- Widget Add-on reference
+- Build-based app reference
+
+Pattern hints prefill only generic metadata, feeds, support flags, properties, methods, and events. They do not copy SAP sample runtime code, assets, dependencies, tenant URLs, or third-party libraries. Reference-only hints route Widget Add-ons and build-based applications to planning guidance outside the v1 local builder.
+
+## Export Contract
+
+The primary builder output is the SAC Resource File upload flow:
+
+1. `widget.json` for the first SAC custom widget upload step.
+2. `<slug>-resources.zip` for the SAC Resource File upload step.
+
+The Resource-ZIP must contain only root-level runtime resources:
+
+```text
+widget.js
+builder.js
+styling.js
+```
+
+Allowed additions are root-level PNG/JPG icons that are referenced by the manifest. Exclude:
+
+- `widget.json`
+- `local-builder/`
+- `design-runtime/`
+- HTML, CSS, Markdown, JSON, tests, source-only helpers, docs, and nested folders
+
+For SAC Resource-ZIP mode, manifest `webcomponents[].url` values should be root-relative, such as `"/widget.js"`, `"/builder.js"`, and `"/styling.js"`.
+
+## Usage Workflow
+
+1. Open `templates/local-builder/index.html` directly.
+2. If direct file mode is blocked, run `node server.mjs` from `templates/local-builder/` and open the loopback URL printed by Node.
+3. Configure metadata, support flags, component tags, properties, feeds, methods, and events.
+4. Optionally apply a Sample Pattern as a generic starting point.
+5. Download `widget.json`.
+6. Download the Resource-ZIP.
+7. Validate generated files with `/widget-validate` and JavaScript syntax checks.
+8. Upload `widget.json` first in SAC.
+9. Upload the Resource-ZIP only after SAC accepts the manifest and enables Resource File upload.
+10. Test with real story data in SAC.
+
+## Validation Checklist
+
+Before delivering a package generated through the local builder:
+
+- `widget.json` parses and includes `methods` and `events` as objects.
+- Component tags are lowercase hyphenated values.
+- Resource-ZIP contains only allowed root-level files.
+- Resource-ZIP does not include builder UI files, preview runtime files, docs, or nested folders.
+- `node --check widget.js`, `node --check builder.js`, and `node --check styling.js` pass for generated component files.
+- Local preview uses the final component files, not preview-only shared helpers.
+- Live SAC import/runtime validation is not claimed unless performed in a tenant.
+
+## Source
+
+- External feature-shape reference: `custom-widgets.de/custom-widget-builder`
+- SAP sample lesson reference: `references/sap-sample-widget-lessons.md`

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/sap-sample-widget-lessons.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/sap-sample-widget-lessons.md
@@ -1,0 +1,65 @@
+# SAP Sample Widget Lessons
+
+Use this reference before generating or reviewing SAC custom widgets that resemble SAP's community sample widgets. The source is the SAP-samples `SAC_Custom_Widgets` directory in `SAP-samples/analytics-cloud-datasphere-community-content`: https://github.com/SAP-samples/analytics-cloud-datasphere-community-content/tree/main/SAC_Custom_Widgets.
+
+## Table of Contents
+
+1. [Source Boundaries](#source-boundaries)
+2. [Sample Audit Matrix](#sample-audit-matrix)
+3. [Reusable Creation Lessons](#reusable-creation-lessons)
+4. [Generation Defaults](#generation-defaults)
+
+---
+
+## Source Boundaries
+
+Treat the SAP samples as reference material, not bundled code. Do not copy sample JavaScript, assets, icons, or build output into generated GPL skill templates unless the license and provenance are reviewed for the target project.
+
+The SAP sample README states the samples are provided for Optimized Story Experience use, are not covered by an SAP support or maintenance obligation, require users to review third-party library licenses, and are developed with the Data Binding property for Optimized View Mode or Optimized and Unified Story Experience. It also warns that when custom widgets are hosted in a different repository or web server, the web component paths in the JSON must be changed.
+
+## Sample Audit Matrix
+
+| Sample folder | Shape observed | Lesson for generation |
+|---------------|----------------|-----------------------|
+| Custom Pie Chart | ECharts-style main component with `myDataSource`, dimension and measure feeds, methods for caption/feed/model access, and click/result events. | For chart samples, start with Data Binding and expose only script methods/events that the story really needs. |
+| Funnel Chart | Main-only chart with root-relative JS URL and dimension/measure feeds. | Keep default chart scaffolds simple before adding panels; feed order must match result access. |
+| Gauge Grade Chart | Main plus styling component, support flag for mobile, array/integer/boolean properties. | Styling panels are useful for visual thresholds and direction toggles; model threshold arrays as manifest properties. |
+| Half Donut Chart | Main-only KPI chart with dimension/measure feeds and caption/feed methods. | KPI charts still often need a dimension feed for labels, not only a measure. |
+| Integrity Node Files | Small Node signing helper. | Integrity generation belongs in tooling or docs, not in the Resource-ZIP runtime files. |
+| Kpi Ring Chart | Main-only ring KPI with width/height-style integer properties. | Keep KPI scaffolds compact and data-bound; avoid overfitting panel controls early. |
+| Line Chart | Main-only chart using a `dataBinding` feed and root-relative JS URL. | Root-relative component URLs are a good default for SAC Resource-ZIP mode. |
+| Nested Pie Chart | Main-only nested chart with dimension/measure feeds and script methods/events. | Hierarchical charts need clear feed mapping and sequential result indexes. |
+| Pareto Chart | Main chart with ordering/selection methods and click event. | Add methods only when story scripts need imperative actions such as ordering or selected-point retrieval. |
+| Sankey Chart with Styling Panel | Main plus styling component, support flags for mobile/bookmark/linked analysis, `stylingSetting` properties, `getDataSource` method. | Flow charts benefit from styling panels and explicit support flags; document linked-analysis expectations. |
+| Sunbrust Chart with Styling Panel | Main plus styling component, support flags for mobile/export/bookmark/linked analysis, boolean/string/string-array properties. | Use the repo spelling `Sunbrust` when auditing, but use "Sunburst" in generated user-facing naming unless matching the upstream folder. |
+| Tree Chart with Styling Panel | Main plus styling component, many script methods, click event, export support. | Tree/hierarchy widgets often need property-backed layout, node, line, and selection controls. |
+| UI5 Gantt Chart | Main, styling, and builder components; custom `types`; many horizon/event/theme methods; dimension/measure feeds. | Complex widgets may need all three component kinds plus custom manifest `types`; keep the local builder generic and route UI5-specific work to dedicated implementation. |
+| Widget Add-on Sample | Add-on manifest uses `extensions[]` with tooltip, plot area, and numeric point extension points, each with main and builder components. | Widget Add-ons are not ordinary top-level `webcomponents` widgets; generate them through the add-on guide, not the v1 local builder path. |
+| World Cloud by Input | Main plus builder component, no data binding, text property and `setText` method. | Input utilities can be property/method driven without model feeds; builder panels are appropriate for authored input. |
+| bar-gradient-binding | Main-only chart with Data Binding, mobile support, and root-relative JS URL. | Visual variants can stay main-only when customization is encoded in data and simple properties. |
+| file-upload-widget-master | Build-based file upload widget with template/localdev/version manifests, imports, builder component, Selection properties, success/failure events, DIS service calls, and React/UI5 dependencies. | Build-based apps are out of scope for the no-install local builder; document API, security, dependency, and tenant validation requirements before implementation. |
+
+## Reusable Creation Lessons
+
+- Prefer Data Binding-first scaffolds for chart-like widgets. Most chart samples use dimension plus `mainStructureMember` measure feeds and assume Optimized View Mode.
+- Use root-relative URLs such as `"/widget.js"`, `"/builder.js"`, and `"/styling.js"` for SAC Resource-ZIP mode. Rework paths when moving to external hosting.
+- Keep main, builder, and styling components separate. Builder/styling panels should dispatch `propertiesChanged` and avoid full rerenders that destroy focus during text edits.
+- Model simple visual controls as portable manifest properties: strings for hex colors, integers/numbers for sizes and thresholds, booleans for toggles, and arrays/custom `types` only when the widget truly needs richer structure.
+- Add methods and events only for story scripting contracts: selected data point retrieval, ordering, text input, open dialog actions, status callbacks, or model/feed helpers.
+- Treat `supportsMobile`, `supportsExport`, `supportsBookmark`, and `supportsLinkedAnalysisFilterOnSelection` as deliberate compatibility claims. Do not enable them just because a similar sample does.
+- For third-party chart libraries, use local vendor assets or an explicitly approved host. The SAP samples demonstrate library-based widgets, but production use still requires license and security review.
+- For Widget Add-ons, use the `extensions[]` manifest model and extension points from the add-on guide. Do not force add-ons into ordinary custom-widget `webcomponents`.
+- For build-based widgets such as file upload or UI5/React wrappers, plan dependency installation, build output, API authentication/authorization, tenant trust, and Resource-ZIP contents separately from the static local builder.
+
+## Generation Defaults
+
+When `/widget-generate` needs a sample-informed starting point:
+
+- Use `data-bound-chart` for line, funnel, pie, nested pie, bar-gradient, and Pareto-like requests.
+- Use `kpi-gauge` for KPI ring, gauge grade, half donut, and compact score displays.
+- Use `flow-hierarchy-chart` for Sankey, Sunburst, Tree, and hierarchy/flow requests.
+- Use `builder-input-utility` for word-cloud/input widgets or authored text utilities.
+- Route Widget Add-ons to `references/widget-addon-guide.md`.
+- Route build-based file upload, UI5 Gantt, React, or service/API widgets to explicit implementation planning instead of the no-install local builder.
+
+Keep the generated scaffold generic. The SAP sample repository teaches structure and caveats; it is not a template source for copied runtime code.

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/builder-panel.js
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/builder-panel.js
@@ -27,7 +27,7 @@
     "  <div class=\"section\">",
     "    <div class=\"title\">General</div>",
     "    <label><span>Title</span><input id=\"titleInput\" type=\"text\"></label>",
-    "    <label><span>Primary color</span><input id=\"primaryColorInput\" type=\"text\" placeholder=\"#0a6ed1\"></label>",
+    "    <label><span>Primary color</span><input id=\"primaryColorInput\" type=\"color\" value=\"#0a6ed1\"></label>",
     "    <label class=\"check\"><input id=\"showValuesInput\" type=\"checkbox\"><span>Show values</span></label>",
     "  </div>",
     "  <div class=\"section\">",
@@ -67,6 +67,18 @@
     }
   }
 
+  function normalizeHexColor(value, fallback) {
+    var color = String(value || "").trim();
+    if (/^#[0-9a-fA-F]{6}$/.test(color)) {
+      return color.toLowerCase();
+    }
+    color = String(fallback || "").trim();
+    if (/^#[0-9a-fA-F]{6}$/.test(color)) {
+      return color.toLowerCase();
+    }
+    return "#0a6ed1";
+  }
+
   class SacWidgetBuilderPanel extends HTMLElement {
     constructor() {
       super();
@@ -90,8 +102,9 @@
         fire(self, { title: event.target.value });
       });
       root.getElementById("primaryColorInput").addEventListener("input", function(event) {
-        self._props.primaryColor = event.target.value;
-        fire(self, { primaryColor: event.target.value });
+        var value = normalizeHexColor(event.target.value, self._props.primaryColor);
+        self._props.primaryColor = value;
+        fire(self, { primaryColor: value });
       });
       root.getElementById("showValuesInput").addEventListener("change", function(event) {
         self._props.showValues = event.target.checked;
@@ -109,12 +122,13 @@
 
     onCustomWidgetBeforeUpdate(changedProperties) {
       assign(this._props, changedProperties);
+      this._props.primaryColor = normalizeHexColor(this._props.primaryColor, "#0a6ed1");
     }
 
     onCustomWidgetAfterUpdate() {
       var root = this._shadowRoot;
       setValue(root, "titleInput", this._props.title);
-      setValue(root, "primaryColorInput", this._props.primaryColor);
+      setValue(root, "primaryColorInput", normalizeHexColor(this._props.primaryColor, "#0a6ed1"));
       setChecked(root, "showValuesInput", this._props.showValues);
       setValue(root, "displayModeInput", this._props.displayMode);
       setValue(root, "notesInput", this._props.notes);
@@ -123,7 +137,7 @@
     get title() { return this._props.title; }
     set title(value) { this._props.title = value; }
     get primaryColor() { return this._props.primaryColor; }
-    set primaryColor(value) { this._props.primaryColor = value; }
+    set primaryColor(value) { this._props.primaryColor = normalizeHexColor(value, this._props.primaryColor); }
     get showValues() { return this._props.showValues; }
     set showValues(value) { this._props.showValues = value; }
     get displayMode() { return this._props.displayMode; }

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/builder-panel.js
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/builder-panel.js
@@ -1,0 +1,136 @@
+/**
+ * SAP Analytics Cloud Custom Widget - Builder Panel Template
+ *
+ * Self-contained design-time configuration panel.
+ * Keep this file at the Resource-ZIP root as builder.js for SAC upload flows.
+ */
+(function() {
+  "use strict";
+
+  var template = document.createElement("template");
+  template.innerHTML = [
+    "<style>",
+    ":host{display:block;font-family:var(--sapFontFamily,Arial,sans-serif);font-size:12px;color:var(--sapTextColor,#32363a);}",
+    ".panel{box-sizing:border-box;padding:12px;width:100%;}",
+    ".section{border-bottom:1px solid #d9d9d9;margin-bottom:14px;padding-bottom:12px;}",
+    ".section:last-child{border-bottom:0;margin-bottom:0;}",
+    ".title{font-weight:700;margin-bottom:8px;}",
+    "label{display:block;margin:0 0 10px;}",
+    "span{display:block;margin-bottom:4px;}",
+    "input,select,textarea{box-sizing:border-box;border:1px solid #89919a;border-radius:4px;font:inherit;padding:7px;width:100%;}",
+    "textarea{min-height:72px;resize:vertical;}",
+    ".check{align-items:center;display:flex;gap:8px;}",
+    ".check input{width:auto;}",
+    ".hint{color:#6a6d70;font-size:11px;line-height:1.35;margin-top:6px;}",
+    "</style>",
+    "<div class=\"panel\">",
+    "  <div class=\"section\">",
+    "    <div class=\"title\">General</div>",
+    "    <label><span>Title</span><input id=\"titleInput\" type=\"text\"></label>",
+    "    <label><span>Primary color</span><input id=\"primaryColorInput\" type=\"text\" placeholder=\"#0a6ed1\"></label>",
+    "    <label class=\"check\"><input id=\"showValuesInput\" type=\"checkbox\"><span>Show values</span></label>",
+    "  </div>",
+    "  <div class=\"section\">",
+    "    <div class=\"title\">Layout</div>",
+    "    <label><span>Display mode</span><select id=\"displayModeInput\"><option value=\"standard\">Standard</option><option value=\"compact\">Compact</option><option value=\"expanded\">Expanded</option></select></label>",
+    "    <label><span>Notes</span><textarea id=\"notesInput\"></textarea></label>",
+    "    <div class=\"hint\">Use SAC native data binding controls for dimensions and measures.</div>",
+    "  </div>",
+    "</div>"
+  ].join("");
+
+  function assign(target, source) {
+    source = source || {};
+    Object.keys(source).forEach(function(key) {
+      target[key] = source[key];
+    });
+    return target;
+  }
+
+  function fire(element, properties) {
+    element.dispatchEvent(new CustomEvent("propertiesChanged", {
+      detail: { properties: properties }
+    }));
+  }
+
+  function setValue(root, id, value) {
+    var input = root.getElementById(id);
+    if (input) {
+      input.value = value === undefined || value === null ? "" : value;
+    }
+  }
+
+  function setChecked(root, id, value) {
+    var input = root.getElementById(id);
+    if (input) {
+      input.checked = Boolean(value);
+    }
+  }
+
+  class SacWidgetBuilderPanel extends HTMLElement {
+    constructor() {
+      super();
+      this._shadowRoot = this.attachShadow({ mode: "open" });
+      this._shadowRoot.appendChild(template.content.cloneNode(true));
+      this._props = {
+        title: "Widget Title",
+        primaryColor: "#0a6ed1",
+        showValues: true,
+        displayMode: "standard",
+        notes: ""
+      };
+      this._wireEvents();
+    }
+
+    _wireEvents() {
+      var root = this._shadowRoot;
+      var self = this;
+      root.getElementById("titleInput").addEventListener("input", function(event) {
+        self._props.title = event.target.value;
+        fire(self, { title: event.target.value });
+      });
+      root.getElementById("primaryColorInput").addEventListener("input", function(event) {
+        self._props.primaryColor = event.target.value;
+        fire(self, { primaryColor: event.target.value });
+      });
+      root.getElementById("showValuesInput").addEventListener("change", function(event) {
+        self._props.showValues = event.target.checked;
+        fire(self, { showValues: event.target.checked });
+      });
+      root.getElementById("displayModeInput").addEventListener("change", function(event) {
+        self._props.displayMode = event.target.value;
+        fire(self, { displayMode: event.target.value });
+      });
+      root.getElementById("notesInput").addEventListener("input", function(event) {
+        self._props.notes = event.target.value;
+        fire(self, { notes: event.target.value });
+      });
+    }
+
+    onCustomWidgetBeforeUpdate(changedProperties) {
+      assign(this._props, changedProperties);
+    }
+
+    onCustomWidgetAfterUpdate() {
+      var root = this._shadowRoot;
+      setValue(root, "titleInput", this._props.title);
+      setValue(root, "primaryColorInput", this._props.primaryColor);
+      setChecked(root, "showValuesInput", this._props.showValues);
+      setValue(root, "displayModeInput", this._props.displayMode);
+      setValue(root, "notesInput", this._props.notes);
+    }
+
+    get title() { return this._props.title; }
+    set title(value) { this._props.title = value; }
+    get primaryColor() { return this._props.primaryColor; }
+    set primaryColor(value) { this._props.primaryColor = value; }
+    get showValues() { return this._props.showValues; }
+    set showValues(value) { this._props.showValues = value; }
+    get displayMode() { return this._props.displayMode; }
+    set displayMode(value) { this._props.displayMode = value; }
+    get notes() { return this._props.notes; }
+    set notes(value) { this._props.notes = value; }
+  }
+
+  customElements.define("sac-widget-builder-panel", SacWidgetBuilderPanel);
+})();

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder-config.json
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder-config.json
@@ -1,0 +1,205 @@
+{
+  "schema": "sap-sac-widget-local-builder/v1",
+  "runtimeName": "SAC Custom Widget Local Builder",
+  "defaultArtifactMode": "sac-two-file",
+  "outputNames": {
+    "manifest": "widget.json",
+    "resourceZipSuffix": "-resources.zip"
+  },
+  "componentFileNames": {
+    "main": "widget.js",
+    "builder": "builder.js",
+    "styling": "styling.js"
+  },
+  "resourceZipExcludedExtensions": [".html", ".css", ".md", ".json"],
+  "resourceZipExcludedPaths": ["design-runtime/"],
+  "defaults": {
+    "name": "Local Builder Widget",
+    "id": "com.company.localbuilderwidget",
+    "version": "1.0.0",
+    "vendor": "Company Name",
+    "description": "Generated with the local SAC custom widget builder",
+    "license": "MIT",
+    "tag": "com-company-localbuilderwidget",
+    "newInstancePrefix": "LocalBuilderWidget",
+    "icon": "",
+    "includeBuilder": true,
+    "includeStyling": true,
+    "supportsMobile": true,
+    "supportsExport": false,
+    "supportsBookmark": true
+  },
+  "controlPalette": [
+    { "type": "string", "label": "Text input", "propertyType": "string", "default": "Sample text" },
+    { "type": "number", "label": "Number", "propertyType": "number", "default": 12 },
+    { "type": "integer", "label": "Integer", "propertyType": "integer", "default": 1 },
+    { "type": "hexColor", "label": "Hex color string", "propertyType": "string", "default": "#0a6ed1" },
+    { "type": "boolean", "label": "Toggle", "propertyType": "boolean", "default": true },
+    { "type": "select", "label": "Dropdown", "propertyType": "string", "default": "standard", "options": ["standard", "compact", "expanded"] },
+    { "type": "textarea", "label": "Textarea", "propertyType": "string", "default": "Description" },
+    { "type": "slider", "label": "Slider", "propertyType": "integer", "default": 50 },
+    { "type": "group", "label": "Group label", "propertyType": "string", "default": "General" },
+    { "type": "divider", "label": "Divider", "propertyType": "boolean", "default": true }
+  ],
+  "defaultProperties": [
+    {
+      "name": "title",
+      "label": "Title",
+      "type": "string",
+      "control": "string",
+      "default": "Local Builder Widget",
+      "description": "Widget title"
+    },
+    {
+      "name": "primaryColor",
+      "label": "Primary Color",
+      "type": "string",
+      "control": "hexColor",
+      "default": "#0a6ed1",
+      "description": "Primary color as a portable hex string"
+    },
+    {
+      "name": "showValues",
+      "label": "Show Values",
+      "type": "boolean",
+      "control": "boolean",
+      "default": true,
+      "description": "Show measure values"
+    }
+  ],
+  "defaultFeeds": [
+    { "id": "dimensions", "description": "Dimensions", "type": "dimension" },
+    { "id": "measures", "description": "Measures", "type": "mainStructureMember" }
+  ],
+  "sampleRows": [
+    {
+      "dimensions_0": { "id": "north", "label": "North" },
+      "measures_0": { "raw": 128000, "formatted": "128,000" }
+    },
+    {
+      "dimensions_0": { "id": "south", "label": "South" },
+      "measures_0": { "raw": 96000, "formatted": "96,000" }
+    },
+    {
+      "dimensions_0": { "id": "west", "label": "West" },
+      "measures_0": { "raw": 143000, "formatted": "143,000" }
+    }
+  ],
+  "patternHints": [
+    {
+      "id": "data-bound-chart",
+      "label": "Data-bound chart",
+      "description": "Generic line, funnel, pie, Pareto, or bar-style scaffold with one dimension feed and one measure feed.",
+      "lesson": "Most SAP chart samples start with Data Binding plus root-relative component URLs for SAC Resource-ZIP mode.",
+      "mode": "prefill",
+      "prefill": {
+        "bindingId": "dataBinding",
+        "components": { "includeBuilder": false, "includeStyling": false },
+        "supportFlags": { "supportsMobile": true, "supportsExport": false, "supportsBookmark": true },
+        "properties": [
+          { "name": "title", "label": "Title", "type": "string", "control": "string", "default": "Data-bound Chart", "description": "Widget title" },
+          { "name": "primaryColor", "label": "Primary Color", "type": "string", "control": "hexColor", "default": "#0a6ed1", "description": "Primary chart color as a hex string" },
+          { "name": "showValues", "label": "Show Values", "type": "boolean", "control": "boolean", "default": true, "description": "Show measure labels" }
+        ],
+        "feeds": [
+          { "id": "dimensions", "description": "Dimensions", "type": "dimension" },
+          { "id": "measures", "description": "Measures", "type": "mainStructureMember" }
+        ],
+        "methods": [],
+        "events": [
+          { "name": "onDataPointSelect", "description": "Raised when a data point is selected" }
+        ]
+      }
+    },
+    {
+      "id": "kpi-gauge",
+      "label": "KPI / gauge",
+      "description": "Compact KPI, ring, gauge, or half-donut scaffold with threshold-oriented properties.",
+      "lesson": "KPI samples still benefit from Data Binding and simple property-backed thresholds before adding richer panel logic.",
+      "mode": "prefill",
+      "prefill": {
+        "bindingId": "dataBinding",
+        "components": { "includeBuilder": false, "includeStyling": true },
+        "supportFlags": { "supportsMobile": true, "supportsExport": false, "supportsBookmark": true },
+        "properties": [
+          { "name": "title", "label": "Title", "type": "string", "control": "string", "default": "KPI Gauge", "description": "Widget title" },
+          { "name": "primaryColor", "label": "Primary Color", "type": "string", "control": "hexColor", "default": "#247a3d", "description": "Positive or primary KPI color" },
+          { "name": "warningThreshold", "label": "Warning Threshold", "type": "integer", "control": "slider", "default": 70, "description": "Warning threshold percentage" },
+          { "name": "reverseScale", "label": "Reverse Scale", "type": "boolean", "control": "boolean", "default": false, "description": "Reverse threshold interpretation" }
+        ],
+        "feeds": [
+          { "id": "dimensions", "description": "Optional labels", "type": "dimension" },
+          { "id": "measures", "description": "KPI measure", "type": "mainStructureMember" }
+        ],
+        "methods": [],
+        "events": []
+      }
+    },
+    {
+      "id": "flow-hierarchy-chart",
+      "label": "Flow / hierarchy",
+      "description": "Generic Sankey, Sunburst, Tree, or hierarchy scaffold with styling-panel-ready controls.",
+      "lesson": "Flow and hierarchy samples use explicit layout properties, styling components, and deliberate support flags.",
+      "mode": "prefill",
+      "prefill": {
+        "bindingId": "dataBinding",
+        "components": { "includeBuilder": false, "includeStyling": true },
+        "supportFlags": { "supportsMobile": true, "supportsExport": true, "supportsBookmark": true },
+        "properties": [
+          { "name": "title", "label": "Title", "type": "string", "control": "string", "default": "Flow Hierarchy", "description": "Widget title" },
+          { "name": "primaryColor", "label": "Node Color", "type": "string", "control": "hexColor", "default": "#0a6ed1", "description": "Default node color" },
+          { "name": "layoutMode", "label": "Layout Mode", "type": "string", "control": "select", "default": "standard", "description": "Generic layout mode" },
+          { "name": "nodeSize", "label": "Node Size", "type": "integer", "control": "slider", "default": 50, "description": "Relative node size" }
+        ],
+        "feeds": [
+          { "id": "dimensions", "description": "Hierarchy dimensions", "type": "dimension" },
+          { "id": "measures", "description": "Flow or node measure", "type": "mainStructureMember" }
+        ],
+        "methods": [
+          { "name": "getSelectedDataPoint", "description": "Return the last selected data point" }
+        ],
+        "events": [
+          { "name": "onClick", "description": "Raised when a node or data point is clicked" }
+        ]
+      }
+    },
+    {
+      "id": "builder-input-utility",
+      "label": "Builder input utility",
+      "description": "Property-driven input utility scaffold for authored text or parameter-style widgets.",
+      "lesson": "Input-focused samples can skip model feeds and use builder panels, properties, methods, and events instead.",
+      "mode": "prefill",
+      "prefill": {
+        "bindingId": "myDataBinding",
+        "components": { "includeBuilder": true, "includeStyling": false },
+        "supportFlags": { "supportsMobile": true, "supportsExport": false, "supportsBookmark": true },
+        "properties": [
+          { "name": "title", "label": "Title", "type": "string", "control": "string", "default": "Input Utility", "description": "Widget title" },
+          { "name": "text", "label": "Text", "type": "string", "control": "textarea", "default": "Sample input text", "description": "Authored input text" },
+          { "name": "primaryColor", "label": "Primary Color", "type": "string", "control": "hexColor", "default": "#0a6ed1", "description": "Primary color as a hex string" }
+        ],
+        "feeds": [],
+        "methods": [
+          { "name": "setText", "description": "Set the input text from SAC scripting" }
+        ],
+        "events": [
+          { "name": "onTextChange", "description": "Raised when text changes" }
+        ]
+      }
+    },
+    {
+      "id": "widget-addon-reference",
+      "label": "Widget Add-on reference",
+      "description": "Reference-only reminder for tooltip, plot area, and numeric point add-ons.",
+      "lesson": "Widget Add-ons use extensions[] manifests and extension points; use the add-on guide instead of this scaffold exporter.",
+      "mode": "reference-only"
+    },
+    {
+      "id": "build-based-app-reference",
+      "label": "Build-based app reference",
+      "description": "Reference-only reminder for file upload, UI5, React, API, or service-backed widgets.",
+      "lesson": "Build-based widgets require dependency, API, security, tenant, and Resource-ZIP planning outside the no-install local builder.",
+      "mode": "reference-only"
+    }
+  ]
+}

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder-config.json
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder-config.json
@@ -12,7 +12,7 @@
     "styling": "styling.js"
   },
   "resourceZipExcludedExtensions": [".html", ".css", ".md", ".json"],
-  "resourceZipExcludedPaths": ["design-runtime/"],
+  "resourceZipExcludedPaths": ["design-runtime/", "local-builder/"],
   "defaults": {
     "name": "Local Builder Widget",
     "id": "com.company.localbuilderwidget",

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder.css
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder.css
@@ -1,0 +1,313 @@
+:root {
+  color-scheme: light;
+  --builder-bg: #eef3f8;
+  --builder-surface: #ffffff;
+  --builder-text: #1d2d3e;
+  --builder-muted: #5b6b7c;
+  --builder-border: #d5dde7;
+  --builder-accent: #0a6ed1;
+  --builder-good: #247a3d;
+  --builder-danger: #b00020;
+  --builder-shadow: 0 14px 34px rgba(29, 45, 62, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--builder-bg);
+  color: var(--builder-text);
+  font-family: Arial, sans-serif;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 1px solid var(--builder-accent);
+  border-radius: 6px;
+  background: var(--builder-accent);
+  color: #ffffff;
+  cursor: pointer;
+  min-height: 34px;
+  padding: 7px 10px;
+}
+
+button.secondary {
+  background: #ffffff;
+  color: var(--builder-accent);
+}
+
+button.danger {
+  border-color: var(--builder-danger);
+  background: #ffffff;
+  color: var(--builder-danger);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.app-header {
+  align-items: center;
+  background: #ffffff;
+  border-bottom: 1px solid var(--builder-border);
+  display: flex;
+  justify-content: space-between;
+  min-height: 72px;
+  padding: 12px 18px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.app-header h1 {
+  font-size: 18px;
+  margin: 0 0 4px;
+}
+
+.app-header p {
+  color: var(--builder-muted);
+  font-size: 12px;
+  margin: 0;
+}
+
+.header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.app-shell {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(260px, 320px) minmax(440px, 1fr) minmax(260px, 320px);
+  padding: 14px;
+}
+
+.panel,
+.builder-section {
+  background: var(--builder-surface);
+  border: 1px solid var(--builder-border);
+  border-radius: 8px;
+  box-shadow: var(--builder-shadow);
+  padding: 12px;
+}
+
+.panel {
+  align-self: start;
+}
+
+.panel-section + .panel-section,
+.builder-section + .builder-section {
+  border-top: 1px solid var(--builder-border);
+  margin-top: 14px;
+  padding-top: 14px;
+}
+
+h2 {
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  margin: 0 0 10px;
+  text-transform: uppercase;
+}
+
+label {
+  color: var(--builder-muted);
+  display: block;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+
+input,
+select,
+textarea {
+  background: #ffffff;
+  border: 1px solid var(--builder-border);
+  border-radius: 6px;
+  color: var(--builder-text);
+  display: block;
+  margin-top: 4px;
+  padding: 8px;
+  width: 100%;
+}
+
+textarea {
+  min-height: 86px;
+  resize: vertical;
+}
+
+.check-row {
+  align-items: center;
+  color: var(--builder-text);
+  display: flex;
+  gap: 8px;
+}
+
+.check-row input {
+  margin: 0;
+  width: auto;
+}
+
+.workspace {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.section-title {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.split {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.palette button {
+  background: #ffffff;
+  color: var(--builder-accent);
+}
+
+.pattern-hints {
+  display: grid;
+  gap: 8px;
+}
+
+.pattern-hint {
+  background: #ffffff;
+  color: var(--builder-text);
+  min-height: 0;
+  padding: 9px;
+  text-align: left;
+  width: 100%;
+}
+
+.pattern-hint.reference {
+  border-color: var(--builder-muted);
+}
+
+.pattern-hint strong,
+.pattern-hint span {
+  display: block;
+}
+
+.pattern-hint strong {
+  font-size: 12px;
+  margin-bottom: 3px;
+}
+
+.pattern-hint span {
+  color: var(--builder-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.rows {
+  display: grid;
+  gap: 10px;
+}
+
+.rows.compact {
+  margin-top: 8px;
+}
+
+.row-card {
+  border: 1px solid var(--builder-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+}
+
+.row-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.row-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.status {
+  border: 1px solid var(--builder-border);
+  border-radius: 6px;
+  color: var(--builder-muted);
+  margin-bottom: 10px;
+  min-height: 36px;
+  padding: 9px 10px;
+}
+
+.status.error {
+  border-color: #ffb4b4;
+  color: var(--builder-danger);
+}
+
+.status.good {
+  border-color: #a7d7b5;
+  color: var(--builder-good);
+}
+
+pre {
+  background: #14202b;
+  border-radius: 8px;
+  color: #f6f8fa;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 0;
+  max-height: 520px;
+  overflow: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+}
+
+ul {
+  color: var(--builder-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.panel-section p {
+  color: var(--builder-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 10px 0 0;
+}
+
+@media (max-width: 1180px) {
+  .app-shell,
+  .split {
+    grid-template-columns: 1fr;
+  }
+
+  .app-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+}

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder.js
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder.js
@@ -1,10 +1,12 @@
 (function() {
   "use strict";
 
-  var RESOURCE_EXCLUDED_EXTENSIONS = [".html", ".css", ".md", ".json"];
-  var RESOURCE_EXCLUDED_PATHS = ["design-runtime/"];
+  var DEFAULT_RESOURCE_EXCLUDED_EXTENSIONS = [".html", ".css", ".md", ".json"];
+  var DEFAULT_RESOURCE_EXCLUDED_PATHS = ["design-runtime/", "local-builder/"];
   var encoder = new TextEncoder();
   var config = readEmbeddedConfig();
+  var RESOURCE_EXCLUDED_EXTENSIONS = configStringList(config.resourceZipExcludedExtensions, DEFAULT_RESOURCE_EXCLUDED_EXTENSIONS);
+  var RESOURCE_EXCLUDED_PATHS = configStringList(config.resourceZipExcludedPaths, DEFAULT_RESOURCE_EXCLUDED_PATHS);
   var patternHints = config.patternHints || [];
   var defaults = config.defaults || {};
   var state = {
@@ -38,6 +40,17 @@
 
   function clone(value) {
     return JSON.parse(JSON.stringify(value || []));
+  }
+
+  function configStringList(value, fallback) {
+    if (!Array.isArray(value)) {
+      return fallback.slice();
+    }
+    return value.filter(function(item) {
+      return typeof item === "string" && item;
+    }).map(function(item) {
+      return item.toLowerCase();
+    });
   }
 
   function readEmbeddedConfig() {
@@ -399,7 +412,7 @@
           property.control = value;
           renderGeneratedPreview();
         }),
-        inputField("Default", String(property.default), function(value) {
+        inputField("Default", property.default, function(value) {
           property.default = parseDefault(value, property.type);
           renderGeneratedPreview();
         }),

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder.js
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder.js
@@ -1,0 +1,1073 @@
+(function() {
+  "use strict";
+
+  var RESOURCE_EXCLUDED_EXTENSIONS = [".html", ".css", ".md", ".json"];
+  var RESOURCE_EXCLUDED_PATHS = ["design-runtime/"];
+  var encoder = new TextEncoder();
+  var config = readEmbeddedConfig();
+  var patternHints = config.patternHints || [];
+  var defaults = config.defaults || {};
+  var state = {
+    metadata: {
+      name: defaults.name || "Local Builder Widget",
+      id: defaults.id || "com.company.localbuilderwidget",
+      version: defaults.version || "1.0.0",
+      vendor: defaults.vendor || "Company Name",
+      description: defaults.description || "Generated with the local SAC custom widget builder",
+      license: defaults.license || "MIT",
+      icon: defaults.icon || "",
+      tag: defaults.tag || "com-company-localbuilderwidget",
+      newInstancePrefix: defaults.newInstancePrefix || "LocalBuilderWidget",
+      includeBuilder: defaults.includeBuilder !== false,
+      includeStyling: defaults.includeStyling !== false,
+      supportsMobile: defaults.supportsMobile !== false,
+      supportsExport: Boolean(defaults.supportsExport),
+      supportsBookmark: defaults.supportsBookmark !== false
+    },
+    bindingId: "myDataBinding",
+    feeds: clone(config.defaultFeeds || []),
+    properties: clone(config.defaultProperties || []),
+    methods: [],
+    events: [],
+    sampleRows: clone(config.sampleRows || [])
+  };
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  function clone(value) {
+    return JSON.parse(JSON.stringify(value || []));
+  }
+
+  function readEmbeddedConfig() {
+    var el = $("local-builder-config");
+    if (!el) {
+      return { schema: "sap-sac-widget-local-builder/v1" };
+    }
+    try {
+      return JSON.parse(el.textContent);
+    } catch (error) {
+      return { schema: "sap-sac-widget-local-builder/v1", loadError: error.message };
+    }
+  }
+
+  function setStatus(message, tone) {
+    var status = $("status");
+    status.textContent = message || "";
+    status.className = "status" + (tone ? " " + tone : "");
+  }
+
+  function setRuntimeMode() {
+    var mode = $("runtimeMode");
+    if (!mode) {
+      return;
+    }
+    if (window.location.protocol === "file:") {
+      mode.textContent = "File mode. Use server.mjs only if your browser blocks local downloads.";
+    } else {
+      mode.textContent = "Loopback server mode. All files remain local to this machine.";
+    }
+  }
+
+  function slugify(text) {
+    return String(text || "widget")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "widget";
+  }
+
+  function pascalCase(text) {
+    var parts = String(text || "Widget").replace(/[^A-Za-z0-9]+/g, " ").trim().split(/\s+/);
+    var out = parts.map(function(part) {
+      return part.charAt(0).toUpperCase() + part.slice(1).replace(/[^A-Za-z0-9]/g, "");
+    }).join("");
+    return out || "Widget";
+  }
+
+  function manifestIdFromName(name) {
+    return "com.company." + slugify(name).replace(/-/g, "");
+  }
+
+  function tagFromId(id) {
+    return String(id || "com.company.widget").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  }
+
+  function propertyNameFromLabel(label) {
+    var text = String(label || "property").replace(/[^A-Za-z0-9]+/g, " ").trim();
+    if (!text) {
+      return "property";
+    }
+    var parts = text.split(/\s+/);
+    var first = parts.shift().toLowerCase();
+    var rest = parts.map(function(part) {
+      return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+    }).join("");
+    var name = first + rest;
+    if (!/^[A-Za-z_$]/.test(name)) {
+      name = "property" + name;
+    }
+    return name;
+  }
+
+  function toJsIdentifier(name) {
+    var id = String(name || "property").replace(/[^A-Za-z0-9_$]/g, "");
+    if (!id || !/^[A-Za-z_$]/.test(id)) {
+      id = "property" + id;
+    }
+    return id;
+  }
+
+  function parseDefault(value, type) {
+    if (type === "boolean") {
+      return value === true || value === "true";
+    }
+    if (type === "integer") {
+      return parseInt(value, 10) || 0;
+    }
+    if (type === "number") {
+      return parseFloat(value) || 0;
+    }
+    return value === undefined || value === null ? "" : String(value);
+  }
+
+  function initForm() {
+    $("widgetName").value = state.metadata.name;
+    $("widgetId").value = state.metadata.id;
+    $("widgetVersion").value = state.metadata.version;
+    $("widgetVendor").value = state.metadata.vendor;
+    $("widgetDescription").value = state.metadata.description;
+    $("widgetIcon").value = state.metadata.icon;
+    $("componentTag").value = state.metadata.tag;
+    $("newInstancePrefix").value = state.metadata.newInstancePrefix;
+    $("includeBuilder").checked = state.metadata.includeBuilder;
+    $("includeStyling").checked = state.metadata.includeStyling;
+    $("supportsMobile").checked = state.metadata.supportsMobile;
+    $("supportsExport").checked = state.metadata.supportsExport;
+    $("supportsBookmark").checked = state.metadata.supportsBookmark;
+    $("bindingId").value = state.bindingId;
+    $("sampleDataEditor").value = JSON.stringify(state.sampleRows, null, 2);
+  }
+
+  function wireStaticEvents() {
+    ["widgetName", "widgetId", "widgetVersion", "widgetVendor", "widgetDescription", "widgetIcon", "componentTag", "newInstancePrefix"].forEach(function(id) {
+      $(id).addEventListener("input", function() {
+        readMetadata();
+        if (id === "widgetName") {
+          state.metadata.id = manifestIdFromName(state.metadata.name);
+          state.metadata.tag = tagFromId(state.metadata.id);
+          state.metadata.newInstancePrefix = pascalCase(state.metadata.name);
+          $("widgetId").value = state.metadata.id;
+          $("componentTag").value = state.metadata.tag;
+          $("newInstancePrefix").value = state.metadata.newInstancePrefix;
+        }
+        renderAll();
+      });
+    });
+    ["includeBuilder", "includeStyling", "supportsMobile", "supportsExport", "supportsBookmark"].forEach(function(id) {
+      $(id).addEventListener("change", function() {
+        readMetadata();
+        renderAll();
+      });
+    });
+    $("bindingId").addEventListener("input", function(event) {
+      state.bindingId = propertyNameFromLabel(event.target.value || "myDataBinding");
+      $("bindingId").value = state.bindingId;
+      renderAll();
+    });
+    $("sampleDataEditor").addEventListener("input", function() {
+      try {
+        state.sampleRows = JSON.parse($("sampleDataEditor").value || "[]");
+        setStatus("Sample data parsed.", "good");
+        renderAll();
+      } catch (error) {
+        setStatus("Sample data JSON is invalid: " + error.message, "error");
+      }
+    });
+    $("addPropertyButton").addEventListener("click", function() {
+      addProperty("string");
+    });
+    $("addFeedButton").addEventListener("click", addFeed);
+    $("addMethodButton").addEventListener("click", addMethod);
+    $("addEventButton").addEventListener("click", addEvent);
+    $("copyManifestButton").addEventListener("click", copyManifest);
+    ["downloadManifestButton", "downloadManifestTop"].forEach(function(id) {
+      $(id).addEventListener("click", downloadManifest);
+    });
+    ["downloadZipButton", "downloadZipTop"].forEach(function(id) {
+      $(id).addEventListener("click", downloadResourceZip);
+    });
+    $("downloadAllButton").addEventListener("click", function() {
+      downloadManifest();
+      window.setTimeout(downloadResourceZip, 250);
+    });
+  }
+
+  function readMetadata() {
+    state.metadata.name = $("widgetName").value.trim() || "Local Builder Widget";
+    state.metadata.id = $("widgetId").value.trim() || manifestIdFromName(state.metadata.name);
+    state.metadata.version = $("widgetVersion").value.trim() || "1.0.0";
+    state.metadata.vendor = $("widgetVendor").value.trim() || "Company Name";
+    state.metadata.description = $("widgetDescription").value.trim();
+    state.metadata.icon = $("widgetIcon").value.trim();
+    state.metadata.tag = $("componentTag").value.trim() || tagFromId(state.metadata.id);
+    state.metadata.newInstancePrefix = $("newInstancePrefix").value.trim() || pascalCase(state.metadata.name);
+    state.metadata.includeBuilder = $("includeBuilder").checked;
+    state.metadata.includeStyling = $("includeStyling").checked;
+    state.metadata.supportsMobile = $("supportsMobile").checked;
+    state.metadata.supportsExport = $("supportsExport").checked;
+    state.metadata.supportsBookmark = $("supportsBookmark").checked;
+  }
+
+  function renderPalette() {
+    var host = $("palette");
+    host.innerHTML = "";
+    (config.controlPalette || []).forEach(function(item) {
+      var button = document.createElement("button");
+      button.type = "button";
+      button.className = "secondary";
+      button.textContent = item.label;
+      button.addEventListener("click", function() {
+        addProperty(item.type);
+      });
+      host.appendChild(button);
+    });
+  }
+
+  function renderPatternHints() {
+    var host = $("patternHintButtons");
+    if (!host) {
+      return;
+    }
+    host.innerHTML = "";
+    patternHints.forEach(function(hint) {
+      var button = document.createElement("button");
+      button.type = "button";
+      button.className = "pattern-hint" + (hint.mode === "reference-only" ? " reference" : "");
+      button.setAttribute("data-pattern-id", hint.id);
+      var title = document.createElement("strong");
+      title.textContent = hint.label;
+      var description = document.createElement("span");
+      description.textContent = hint.description;
+      button.appendChild(title);
+      button.appendChild(description);
+      button.addEventListener("click", function() {
+        applyPatternHint(hint.id);
+      });
+      host.appendChild(button);
+    });
+  }
+
+  function findPatternHint(id) {
+    for (var i = 0; i < patternHints.length; i++) {
+      if (patternHints[i].id === id) {
+        return patternHints[i];
+      }
+    }
+    return null;
+  }
+
+  function applyPatternHint(id) {
+    var hint = findPatternHint(id);
+    if (!hint) {
+      setStatus("Pattern hint not found.", "error");
+      return;
+    }
+    if (hint.mode === "reference-only") {
+      setStatus(hint.lesson, "good");
+      return;
+    }
+    var prefill = hint.prefill || {};
+    readMetadata();
+    if (prefill.components) {
+      if (typeof prefill.components.includeBuilder === "boolean") {
+        state.metadata.includeBuilder = prefill.components.includeBuilder;
+      }
+      if (typeof prefill.components.includeStyling === "boolean") {
+        state.metadata.includeStyling = prefill.components.includeStyling;
+      }
+    }
+    if (prefill.supportFlags) {
+      if (typeof prefill.supportFlags.supportsMobile === "boolean") {
+        state.metadata.supportsMobile = prefill.supportFlags.supportsMobile;
+      }
+      if (typeof prefill.supportFlags.supportsExport === "boolean") {
+        state.metadata.supportsExport = prefill.supportFlags.supportsExport;
+      }
+      if (typeof prefill.supportFlags.supportsBookmark === "boolean") {
+        state.metadata.supportsBookmark = prefill.supportFlags.supportsBookmark;
+      }
+    }
+    state.bindingId = prefill.bindingId || state.bindingId;
+    state.properties = clone(prefill.properties || state.properties);
+    state.feeds = clone(prefill.feeds || []);
+    state.methods = clone(prefill.methods || []);
+    state.events = clone(prefill.events || []);
+    initForm();
+    renderAll();
+    setStatus("Applied pattern: " + hint.label + ". " + hint.lesson, "good");
+  }
+
+  function addProperty(controlType) {
+    var paletteItem = findPaletteItem(controlType);
+    var label = paletteItem.label || "Property";
+    var name = uniqueName(propertyNameFromLabel(label), state.properties.map(function(item) { return item.name; }));
+    state.properties.push({
+      name: name,
+      label: label,
+      type: paletteItem.propertyType || "string",
+      control: controlType,
+      default: paletteItem.default,
+      description: label
+    });
+    renderAll();
+  }
+
+  function findPaletteItem(type) {
+    var items = config.controlPalette || [];
+    for (var i = 0; i < items.length; i++) {
+      if (items[i].type === type) {
+        return items[i];
+      }
+    }
+    return { type: "string", label: "Text input", propertyType: "string", default: "" };
+  }
+
+  function uniqueName(base, existing) {
+    var name = base;
+    var index = 2;
+    while (existing.indexOf(name) !== -1) {
+      name = base + index;
+      index += 1;
+    }
+    return name;
+  }
+
+  function addFeed() {
+    state.feeds.push({
+      id: uniqueName("feed", state.feeds.map(function(item) { return item.id; })),
+      description: "Feed",
+      type: "dimension"
+    });
+    renderAll();
+  }
+
+  function addMethod() {
+    state.methods.push({
+      name: uniqueName("refresh", state.methods.map(function(item) { return item.name; })),
+      description: "Method exposed to SAC scripting"
+    });
+    renderAll();
+  }
+
+  function addEvent() {
+    state.events.push({
+      name: uniqueName("onSelectionChange", state.events.map(function(item) { return item.name; })),
+      description: "Event dispatched by the widget"
+    });
+    renderAll();
+  }
+
+  function renderRows() {
+    renderPropertyRows();
+    renderFeedRows();
+    renderNamedRows("methodRows", state.methods, "method");
+    renderNamedRows("eventRows", state.events, "event");
+  }
+
+  function renderPropertyRows() {
+    var host = $("propertyRows");
+    host.innerHTML = "";
+    state.properties.forEach(function(property, index) {
+      var card = document.createElement("div");
+      card.className = "row-card";
+      card.appendChild(rowGrid([
+        inputField("Name", property.name, function(value) {
+          property.name = propertyNameFromLabel(value);
+          renderGeneratedPreview();
+        }),
+        inputField("Label", property.label, function(value) {
+          property.label = value;
+          renderGeneratedPreview();
+        }),
+        selectField("Type", property.type, ["string", "integer", "number", "boolean", "array", "object"], function(value) {
+          property.type = value;
+          property.default = parseDefault(property.default, value);
+          renderGeneratedPreview();
+        }),
+        selectField("Control", property.control, (config.controlPalette || []).map(function(item) { return item.type; }), function(value) {
+          property.control = value;
+          renderGeneratedPreview();
+        }),
+        inputField("Default", String(property.default), function(value) {
+          property.default = parseDefault(value, property.type);
+          renderGeneratedPreview();
+        }),
+        inputField("Description", property.description || "", function(value) {
+          property.description = value;
+          renderGeneratedPreview();
+        })
+      ]));
+      card.appendChild(actions(function() {
+        state.properties.splice(index, 1);
+        renderAll();
+      }));
+      host.appendChild(card);
+    });
+  }
+
+  function renderFeedRows() {
+    var host = $("feedRows");
+    host.innerHTML = "";
+    state.feeds.forEach(function(feed, index) {
+      var card = document.createElement("div");
+      card.className = "row-card";
+      card.appendChild(rowGrid([
+        inputField("ID", feed.id, function(value) {
+          feed.id = propertyNameFromLabel(value);
+          renderGeneratedPreview();
+        }),
+        inputField("Description", feed.description, function(value) {
+          feed.description = value;
+          renderGeneratedPreview();
+        }),
+        selectField("Type", feed.type, ["dimension", "mainStructureMember", "measure"], function(value) {
+          feed.type = value;
+          renderGeneratedPreview();
+        })
+      ]));
+      card.appendChild(actions(function() {
+        state.feeds.splice(index, 1);
+        renderAll();
+      }));
+      host.appendChild(card);
+    });
+  }
+
+  function renderNamedRows(hostId, list, kind) {
+    var host = $(hostId);
+    host.innerHTML = "";
+    list.forEach(function(item, index) {
+      var card = document.createElement("div");
+      card.className = "row-card";
+      card.appendChild(rowGrid([
+        inputField(kind + " name", item.name, function(value) {
+          item.name = propertyNameFromLabel(value);
+          renderGeneratedPreview();
+        }),
+        inputField("Description", item.description, function(value) {
+          item.description = value;
+          renderGeneratedPreview();
+        })
+      ]));
+      card.appendChild(actions(function() {
+        list.splice(index, 1);
+        renderAll();
+      }));
+      host.appendChild(card);
+    });
+  }
+
+  function rowGrid(children) {
+    var grid = document.createElement("div");
+    grid.className = "row-grid";
+    children.forEach(function(child) {
+      grid.appendChild(child);
+    });
+    return grid;
+  }
+
+  function inputField(labelText, value, onInput) {
+    var label = document.createElement("label");
+    label.textContent = labelText;
+    var input = document.createElement("input");
+    input.type = "text";
+    input.value = value === undefined || value === null ? "" : value;
+    input.addEventListener("input", function() {
+      onInput(input.value);
+    });
+    label.appendChild(input);
+    return label;
+  }
+
+  function selectField(labelText, value, options, onChange) {
+    var label = document.createElement("label");
+    label.textContent = labelText;
+    var select = document.createElement("select");
+    options.forEach(function(optionValue) {
+      var option = document.createElement("option");
+      option.value = optionValue;
+      option.textContent = optionValue;
+      select.appendChild(option);
+    });
+    select.value = value;
+    select.addEventListener("change", function() {
+      onChange(select.value);
+    });
+    label.appendChild(select);
+    return label;
+  }
+
+  function actions(onDelete) {
+    var row = document.createElement("div");
+    row.className = "row-actions";
+    var button = document.createElement("button");
+    button.type = "button";
+    button.className = "danger";
+    button.textContent = "Remove";
+    button.addEventListener("click", onDelete);
+    row.appendChild(button);
+    return row;
+  }
+
+  function buildManifest() {
+    readMetadata();
+    var components = [
+      component("main", state.metadata.tag, "/" + config.componentFileNames.main)
+    ];
+    if (state.metadata.includeBuilder) {
+      components.push(component("builder", state.metadata.tag + "-builder", "/" + config.componentFileNames.builder));
+    }
+    if (state.metadata.includeStyling) {
+      components.push(component("styling", state.metadata.tag + "-styling", "/" + config.componentFileNames.styling));
+    }
+
+    var manifest = {
+      id: state.metadata.id,
+      version: state.metadata.version,
+      name: state.metadata.name,
+      description: state.metadata.description,
+      vendor: state.metadata.vendor,
+      license: state.metadata.license || "MIT",
+      icon: state.metadata.icon,
+      newInstancePrefix: state.metadata.newInstancePrefix,
+      supportsMobile: state.metadata.supportsMobile,
+      supportsExport: state.metadata.supportsExport,
+      supportsBookmark: state.metadata.supportsBookmark,
+      webcomponents: components,
+      properties: manifestProperties(),
+      methods: objectFromNamedList(state.methods),
+      events: objectFromNamedList(state.events)
+    };
+    if (state.feeds.length > 0) {
+      manifest.dataBindings = {};
+      manifest.dataBindings[state.bindingId || "myDataBinding"] = { feeds: state.feeds };
+    }
+    return manifest;
+  }
+
+  function component(kind, tag, url) {
+    return {
+      kind: kind,
+      tag: tag,
+      url: url,
+      integrity: "",
+      ignoreIntegrity: true
+    };
+  }
+
+  function manifestProperties() {
+    var out = {};
+    state.properties.forEach(function(property) {
+      out[property.name] = {
+        type: property.type,
+        description: property.description || property.label || property.name,
+        default: parseDefault(property.default, property.type)
+      };
+    });
+    return out;
+  }
+
+  function objectFromNamedList(list) {
+    var out = {};
+    list.forEach(function(item) {
+      if (item.name) {
+        out[item.name] = { description: item.description || item.name };
+      }
+    });
+    return out;
+  }
+
+  function buildFiles() {
+    var files = {};
+    files[config.componentFileNames.main] = buildMainComponent();
+    if (state.metadata.includeBuilder) {
+      files[config.componentFileNames.builder] = buildPanelComponent("builder", state.metadata.tag + "-builder");
+    }
+    if (state.metadata.includeStyling) {
+      files[config.componentFileNames.styling] = buildPanelComponent("styling", state.metadata.tag + "-styling");
+    }
+    return files;
+  }
+
+  function defaultsObject() {
+    var out = {};
+    state.properties.forEach(function(property) {
+      out[property.name] = parseDefault(property.default, property.type);
+    });
+    return out;
+  }
+
+  function buildMainComponent() {
+    var className = pascalCase(state.metadata.name);
+    var tag = state.metadata.tag;
+    var bindingId = state.bindingId || "myDataBinding";
+    var defaultsJson = JSON.stringify(defaultsObject(), null, 6);
+    var accessors = state.properties.map(function(property) {
+      var id = toJsIdentifier(property.name);
+      var name = JSON.stringify(property.name);
+      return [
+        "    get " + id + "() { return this._props[" + name + "]; }",
+        "    set " + id + "(value) {",
+        "      this._props[" + name + "] = value;",
+        "      this.dispatchEvent(new CustomEvent(\"propertiesChanged\", { detail: { properties: { " + id + ": value } } }));",
+        "      this._render();",
+        "    }"
+      ].join("\n");
+    }).join("\n\n");
+
+    return [
+      "(function() {",
+      "  \"use strict\";",
+      "",
+      "  var template = document.createElement(\"template\");",
+      "  template.innerHTML = [",
+      "    \"<style>\",",
+      "    \":host{display:block;width:100%;height:100%;font-family:var(--sapFontFamily,Arial,sans-serif);color:var(--sapTextColor,#1d2d3e);}\",",
+      "    \".wrap{box-sizing:border-box;height:100%;padding:16px;background:var(--sapBackgroundColor,#fff);}\",",
+      "    \".title{font-size:16px;font-weight:700;margin-bottom:12px;}\",",
+      "    \".bar{align-items:center;display:grid;gap:8px;grid-template-columns:minmax(90px,1fr) 3fr auto;margin:8px 0;}\",",
+      "    \".track{background:#e5eef7;border-radius:4px;height:12px;overflow:hidden;}\",",
+      "    \".fill{background:var(--widget-primary-color,#0a6ed1);height:100%;}\",",
+      "    \".empty{color:#6a6d70;font-size:12px;}\",",
+      "    \"</style>\",",
+      "    \"<div class=\\\"wrap\\\"><div id=\\\"title\\\" class=\\\"title\\\"></div><div id=\\\"content\\\"></div></div>\"",
+      "  ].join(\"\");",
+      "",
+      "  function assign(target, source) {",
+      "    source = source || {};",
+      "    Object.keys(source).forEach(function(key) { target[key] = source[key]; });",
+      "    return target;",
+      "  }",
+      "",
+      "  function escapeText(value) {",
+      "    return String(value === undefined || value === null ? \"\" : value);",
+      "  }",
+      "",
+      "  class " + className + " extends HTMLElement {",
+      "    constructor() {",
+      "      super();",
+      "      this._shadowRoot = this.attachShadow({ mode: \"open\" });",
+      "      this._shadowRoot.appendChild(template.content.cloneNode(true));",
+      "      this._props = assign({}, " + defaultsJson.replace(/\n/g, "\n      ") + ");",
+      "    }",
+      "",
+      "    connectedCallback() { this._render(); }",
+      "",
+      "    onCustomWidgetBeforeUpdate(changedProperties) {",
+      "      assign(this._props, changedProperties);",
+      "    }",
+      "",
+      "    onCustomWidgetAfterUpdate() { this._render(); }",
+      "",
+      "    onCustomWidgetResize() { this._render(); }",
+      "",
+      "    onCustomWidgetDestroy() {}",
+      "",
+      "    _dataRows() {",
+      "      var binding = this[" + JSON.stringify(bindingId) + "] || (this.dataBindings && this.dataBindings.getDataBinding && this.dataBindings.getDataBinding(" + JSON.stringify(bindingId) + "));",
+      "      return binding && Array.isArray(binding.data) ? binding.data : [];",
+      "    }",
+      "",
+      "    _render() {",
+      "      var titleEl = this._shadowRoot.getElementById(\"title\");",
+      "      var contentEl = this._shadowRoot.getElementById(\"content\");",
+      "      var color = this._props.primaryColor || \"#0a6ed1\";",
+      "      this.style.setProperty(\"--widget-primary-color\", color);",
+      "      titleEl.textContent = this._props.title || " + JSON.stringify(state.metadata.name) + ";",
+      "      var rows = this._dataRows();",
+      "      contentEl.innerHTML = \"\";",
+      "      if (!rows.length) {",
+      "        var empty = document.createElement(\"div\");",
+      "        empty.className = \"empty\";",
+      "        empty.textContent = \"Bind data in SAC to populate this widget.\";",
+      "        contentEl.appendChild(empty);",
+      "        return;",
+      "      }",
+      "      var max = 0;",
+      "      rows.forEach(function(row) {",
+      "        var raw = row.measures_0 && typeof row.measures_0.raw === \"number\" ? row.measures_0.raw : 0;",
+      "        if (raw > max) { max = raw; }",
+      "      });",
+      "      rows.forEach(function(row) {",
+      "        var label = row.dimensions_0 && row.dimensions_0.label ? row.dimensions_0.label : \"Item\";",
+      "        var raw = row.measures_0 && typeof row.measures_0.raw === \"number\" ? row.measures_0.raw : 0;",
+      "        var formatted = row.measures_0 && row.measures_0.formatted ? row.measures_0.formatted : String(raw);",
+      "        var bar = document.createElement(\"div\");",
+      "        bar.className = \"bar\";",
+      "        var labelEl = document.createElement(\"div\");",
+      "        labelEl.textContent = escapeText(label);",
+      "        var track = document.createElement(\"div\");",
+      "        track.className = \"track\";",
+      "        var fill = document.createElement(\"div\");",
+      "        fill.className = \"fill\";",
+      "        fill.style.width = max > 0 ? Math.round((raw / max) * 100) + \"%\" : \"0%\";",
+      "        var valueEl = document.createElement(\"div\");",
+      "        valueEl.textContent = this._props.showValues === false ? \"\" : escapeText(formatted);",
+      "        track.appendChild(fill);",
+      "        bar.appendChild(labelEl);",
+      "        bar.appendChild(track);",
+      "        bar.appendChild(valueEl);",
+      "        contentEl.appendChild(bar);",
+      "      }, this);",
+      "    }",
+      "",
+      accessors,
+      "  }",
+      "",
+      "  customElements.define(" + JSON.stringify(tag) + ", " + className + ");",
+      "})();",
+      ""
+    ].join("\n");
+  }
+
+  function buildPanelComponent(kind, tag) {
+    var className = pascalCase(state.metadata.name + " " + kind);
+    var controls = state.properties.map(function(property) {
+      return panelControlHtml(property);
+    }).join("");
+    var listeners = state.properties.map(function(property) {
+      return panelListenerCode(property);
+    }).join("\n");
+    var sync = state.properties.map(function(property) {
+      return panelSyncCode(property);
+    }).join("\n");
+    var accessors = state.properties.map(function(property) {
+      var id = toJsIdentifier(property.name);
+      var name = JSON.stringify(property.name);
+      return "    get " + id + "() { return this._props[" + name + "]; }\n    set " + id + "(value) { this._props[" + name + "] = value; }";
+    }).join("\n");
+    return [
+      "(function() {",
+      "  \"use strict\";",
+      "  var template = document.createElement(\"template\");",
+      "  template.innerHTML = " + JSON.stringify([
+        "<style>",
+        ":host{display:block;font-family:var(--sapFontFamily,Arial,sans-serif);font-size:12px;color:var(--sapTextColor,#32363a);}",
+        ".panel{box-sizing:border-box;padding:12px;width:100%;}",
+        ".section{border-bottom:1px solid #d9d9d9;margin-bottom:14px;padding-bottom:12px;}",
+        ".section:last-child{border-bottom:0;margin-bottom:0;}",
+        ".title{font-weight:700;margin-bottom:8px;}",
+        "label{display:block;margin:0 0 10px;}",
+        "span{display:block;margin-bottom:4px;}",
+        "input,select,textarea{box-sizing:border-box;border:1px solid #89919a;border-radius:4px;font:inherit;padding:7px;width:100%;}",
+        "textarea{min-height:72px;resize:vertical;}",
+        ".check{align-items:center;display:flex;gap:8px;}",
+        ".check input{width:auto;}",
+        ".hint{color:#6a6d70;font-size:11px;line-height:1.35;margin-top:6px;}",
+        "</style>",
+        "<div class=\"panel\"><div class=\"section\"><div class=\"title\">" + (kind === "builder" ? "Builder" : "Styling") + " Properties</div>" + controls + "</div><div class=\"hint\">Upload widget.json first, then the Resource-ZIP containing this component.</div></div>"
+      ].join("")) + ";",
+      "",
+      "  function assign(target, source) {",
+      "    source = source || {};",
+      "    Object.keys(source).forEach(function(key) { target[key] = source[key]; });",
+      "    return target;",
+      "  }",
+      "  function fire(element, properties) {",
+      "    element.dispatchEvent(new CustomEvent(\"propertiesChanged\", { detail: { properties: properties } }));",
+      "  }",
+      "",
+      "  class " + className + " extends HTMLElement {",
+      "    constructor() {",
+      "      super();",
+      "      this._shadowRoot = this.attachShadow({ mode: \"open\" });",
+      "      this._shadowRoot.appendChild(template.content.cloneNode(true));",
+      "      this._props = assign({}, " + JSON.stringify(defaultsObject(), null, 6).replace(/\n/g, "\n      ") + ");",
+      "      this._wireEvents();",
+      "    }",
+      "    _wireEvents() {",
+      listeners,
+      "    }",
+      "    onCustomWidgetBeforeUpdate(changedProperties) { assign(this._props, changedProperties); }",
+      "    onCustomWidgetAfterUpdate() {",
+      sync,
+      "    }",
+      accessors,
+      "  }",
+      "  customElements.define(" + JSON.stringify(tag) + ", " + className + ");",
+      "})();",
+      ""
+    ].join("\n");
+  }
+
+  function panelControlHtml(property) {
+    var id = "prop_" + toJsIdentifier(property.name);
+    var label = escapeHtml(property.label || property.name);
+    if (property.control === "boolean" || property.type === "boolean" || property.control === "divider") {
+      return "<label class=\"check\"><input id=\"" + id + "\" type=\"checkbox\"><span>" + label + "</span></label>";
+    }
+    if (property.control === "textarea") {
+      return "<label><span>" + label + "</span><textarea id=\"" + id + "\"></textarea></label>";
+    }
+    if (property.control === "select") {
+      var palette = findPaletteItem("select");
+      var options = (palette.options || ["standard", "compact", "expanded"]).map(function(option) {
+        return "<option value=\"" + escapeHtml(option) + "\">" + escapeHtml(option) + "</option>";
+      }).join("");
+      return "<label><span>" + label + "</span><select id=\"" + id + "\">" + options + "</select></label>";
+    }
+    if (property.control === "slider") {
+      return "<label><span>" + label + "</span><input id=\"" + id + "\" type=\"range\" min=\"0\" max=\"100\"></label>";
+    }
+    return "<label><span>" + label + "</span><input id=\"" + id + "\" type=\"text\"></label>";
+  }
+
+  function panelListenerCode(property) {
+    var id = "prop_" + toJsIdentifier(property.name);
+    var name = JSON.stringify(property.name);
+    var eventName = property.type === "boolean" || property.control === "boolean" || property.control === "divider" || property.control === "select" ? "change" : "input";
+    var readValue = "event.target.value";
+    if (property.type === "boolean" || property.control === "boolean" || property.control === "divider") {
+      readValue = "event.target.checked";
+    } else if (property.type === "integer") {
+      readValue = "parseInt(event.target.value, 10) || 0";
+    } else if (property.type === "number") {
+      readValue = "parseFloat(event.target.value) || 0";
+    }
+    return [
+      "      this._shadowRoot.getElementById(" + JSON.stringify(id) + ").addEventListener(" + JSON.stringify(eventName) + ", function(event) {",
+      "        var properties = {};",
+      "        properties[" + name + "] = " + readValue + ";",
+      "        this._props[" + name + "] = properties[" + name + "];",
+      "        fire(this, properties);",
+      "      }.bind(this));"
+    ].join("\n");
+  }
+
+  function panelSyncCode(property) {
+    var id = "prop_" + toJsIdentifier(property.name);
+    var name = JSON.stringify(property.name);
+    if (property.type === "boolean" || property.control === "boolean" || property.control === "divider") {
+      return "      this._shadowRoot.getElementById(" + JSON.stringify(id) + ").checked = Boolean(this._props[" + name + "]);";
+    }
+    return "      this._shadowRoot.getElementById(" + JSON.stringify(id) + ").value = this._props[" + name + "] === undefined ? \"\" : this._props[" + name + "];";
+  }
+
+  function escapeHtml(value) {
+    return String(value === undefined || value === null ? "" : value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function resourceZipEntries(files) {
+    var out = {};
+    Object.keys(files).forEach(function(fileName) {
+      var lower = fileName.toLowerCase();
+      var excludedExtension = RESOURCE_EXCLUDED_EXTENSIONS.some(function(extension) {
+        return lower.endsWith(extension);
+      });
+      var excludedPath = RESOURCE_EXCLUDED_PATHS.some(function(prefix) {
+        return lower.indexOf(prefix) === 0;
+      });
+      if (!excludedExtension && !excludedPath && lower.endsWith(".js") && fileName.indexOf("/") === -1 && fileName.indexOf("\\") === -1) {
+        out[fileName] = files[fileName];
+      }
+    });
+    return out;
+  }
+
+  function generatedArtifactNames() {
+    return {
+      manifest: config.outputNames.manifest || "widget.json",
+      resourceZip: slugify(state.metadata.name) + (config.outputNames.resourceZipSuffix || "-resources.zip")
+    };
+  }
+
+  function renderGeneratedPreview() {
+    var manifest = buildManifest();
+    $("manifestPreview").textContent = JSON.stringify(manifest, null, 2);
+    var files = buildFiles();
+    var entries = resourceZipEntries(files);
+    var names = generatedArtifactNames();
+    var list = $("fileList");
+    list.innerHTML = "";
+    [names.manifest, names.resourceZip].forEach(function(name) {
+      var item = document.createElement("li");
+      item.textContent = name;
+      list.appendChild(item);
+    });
+    Object.keys(entries).forEach(function(name) {
+      var item = document.createElement("li");
+      item.textContent = "Resource-ZIP entry: " + name;
+      list.appendChild(item);
+    });
+  }
+
+  function renderAll() {
+    readMetadata();
+    renderRows();
+    renderGeneratedPreview();
+  }
+
+  function downloadManifest() {
+    var names = generatedArtifactNames();
+    downloadFile(names.manifest, JSON.stringify(buildManifest(), null, 2), "application/json");
+    setStatus("Downloaded widget.json. Upload it first in SAC.", "good");
+  }
+
+  function downloadResourceZip() {
+    var names = generatedArtifactNames();
+    var zipBytes = createZip(resourceZipEntries(buildFiles()));
+    downloadBlob(names.resourceZip, new Blob([zipBytes], { type: "application/zip" }));
+    setStatus("Downloaded Resource-ZIP with root-level JavaScript only.", "good");
+  }
+
+  function copyManifest() {
+    var text = JSON.stringify(buildManifest(), null, 2);
+    if (!navigator.clipboard) {
+      setStatus("Clipboard API unavailable. Use Download widget.json instead.", "error");
+      return;
+    }
+    navigator.clipboard.writeText(text).then(function() {
+      setStatus("Manifest copied.", "good");
+    }).catch(function(error) {
+      setStatus("Copy failed: " + error.message, "error");
+    });
+  }
+
+  function downloadFile(filename, content, type) {
+    downloadBlob(filename, new Blob([content], { type: type }));
+  }
+
+  function downloadBlob(filename, blob) {
+    var url = URL.createObjectURL(blob);
+    var link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  function crc32(bytes) {
+    var table = crc32.table;
+    if (!table) {
+      table = [];
+      for (var i = 0; i < 256; i++) {
+        var c = i;
+        for (var j = 0; j < 8; j++) {
+          c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        }
+        table[i] = c >>> 0;
+      }
+      crc32.table = table;
+    }
+    var crc = 0xffffffff;
+    for (var index = 0; index < bytes.length; index++) {
+      crc = table[(crc ^ bytes[index]) & 0xff] ^ (crc >>> 8);
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+  }
+
+  function writeU16(out, value) {
+    out.push(value & 0xff, (value >>> 8) & 0xff);
+  }
+
+  function writeU32(out, value) {
+    out.push(value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff);
+  }
+
+  function dosTime(date) {
+    return (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2);
+  }
+
+  function dosDate(date) {
+    return ((date.getFullYear() - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate();
+  }
+
+  function createZip(files) {
+    var chunks = [];
+    var central = [];
+    var offset = 0;
+    var now = new Date();
+    Object.keys(files).forEach(function(name) {
+      var nameBytes = encoder.encode(name);
+      var dataBytes = encoder.encode(files[name]);
+      var crc = crc32(dataBytes);
+      var local = [];
+      writeU32(local, 0x04034b50);
+      writeU16(local, 20);
+      writeU16(local, 0);
+      writeU16(local, 0);
+      writeU16(local, dosTime(now));
+      writeU16(local, dosDate(now));
+      writeU32(local, crc);
+      writeU32(local, dataBytes.length);
+      writeU32(local, dataBytes.length);
+      writeU16(local, nameBytes.length);
+      writeU16(local, 0);
+      chunks.push(Uint8Array.from(local), nameBytes, dataBytes);
+
+      var record = [];
+      writeU32(record, 0x02014b50);
+      writeU16(record, 20);
+      writeU16(record, 20);
+      writeU16(record, 0);
+      writeU16(record, 0);
+      writeU16(record, dosTime(now));
+      writeU16(record, dosDate(now));
+      writeU32(record, crc);
+      writeU32(record, dataBytes.length);
+      writeU32(record, dataBytes.length);
+      writeU16(record, nameBytes.length);
+      writeU16(record, 0);
+      writeU16(record, 0);
+      writeU16(record, 0);
+      writeU16(record, 0);
+      writeU32(record, 0);
+      writeU32(record, offset);
+      central.push(Uint8Array.from(record), nameBytes);
+      offset += local.length + nameBytes.length + dataBytes.length;
+    });
+    var centralSize = central.reduce(function(total, chunk) { return total + chunk.length; }, 0);
+    var end = [];
+    writeU32(end, 0x06054b50);
+    writeU16(end, 0);
+    writeU16(end, 0);
+    writeU16(end, Object.keys(files).length);
+    writeU16(end, Object.keys(files).length);
+    writeU32(end, centralSize);
+    writeU32(end, offset);
+    writeU16(end, 0);
+    return concatBytes(chunks.concat(central).concat([Uint8Array.from(end)]));
+  }
+
+  function concatBytes(parts) {
+    var total = parts.reduce(function(sum, part) { return sum + part.length; }, 0);
+    var out = new Uint8Array(total);
+    var offset = 0;
+    parts.forEach(function(part) {
+      out.set(part, offset);
+      offset += part.length;
+    });
+    return out;
+  }
+
+  function start() {
+    setRuntimeMode();
+    if (config.loadError) {
+      setStatus("Embedded config failed to parse: " + config.loadError, "error");
+    }
+    initForm();
+    renderPatternHints();
+    renderPalette();
+    wireStaticEvents();
+    renderAll();
+  }
+
+  start();
+})();

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/index.html
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/index.html
@@ -136,7 +136,7 @@
       "styling": "styling.js"
     },
     "resourceZipExcludedExtensions": [".html", ".css", ".md", ".json"],
-    "resourceZipExcludedPaths": ["design-runtime/"],
+    "resourceZipExcludedPaths": ["design-runtime/", "local-builder/"],
     "defaults": {
       "name": "Local Builder Widget",
       "id": "com.company.localbuilderwidget",

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/index.html
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/index.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SAC Custom Widget Local Builder</title>
+  <link rel="stylesheet" href="./builder.css">
+</head>
+<body>
+  <header class="app-header">
+    <div>
+      <h1>SAC Custom Widget Local Builder</h1>
+      <p id="runtimeMode">Loading local builder...</p>
+    </div>
+    <div class="header-actions">
+      <button id="downloadManifestTop" type="button">Download widget.json</button>
+      <button id="downloadZipTop" type="button">Download Resource-ZIP</button>
+    </div>
+  </header>
+
+  <main class="app-shell">
+    <aside class="panel">
+      <section class="panel-section">
+        <h2>Metadata</h2>
+        <label for="widgetName">Name</label>
+        <input id="widgetName" type="text">
+        <label for="widgetId">ID</label>
+        <input id="widgetId" type="text">
+        <label for="widgetVersion">Version</label>
+        <input id="widgetVersion" type="text">
+        <label for="widgetVendor">Vendor</label>
+        <input id="widgetVendor" type="text">
+        <label for="widgetDescription">Description</label>
+        <textarea id="widgetDescription"></textarea>
+        <label for="widgetIcon">Icon path</label>
+        <input id="widgetIcon" type="text">
+      </section>
+
+      <section class="panel-section">
+        <h2>Components</h2>
+        <label class="check-row"><input id="includeBuilder" type="checkbox"> Builder panel</label>
+        <label class="check-row"><input id="includeStyling" type="checkbox"> Styling panel</label>
+        <label class="check-row"><input id="supportsMobile" type="checkbox"> Supports mobile</label>
+        <label class="check-row"><input id="supportsExport" type="checkbox"> Supports export</label>
+        <label class="check-row"><input id="supportsBookmark" type="checkbox"> Supports bookmark</label>
+      </section>
+
+      <section class="panel-section">
+        <h2>Component Names</h2>
+        <label for="componentTag">Main tag</label>
+        <input id="componentTag" type="text">
+        <label for="newInstancePrefix">Instance prefix</label>
+        <input id="newInstancePrefix" type="text">
+      </section>
+
+      <section class="panel-section">
+        <h2>Sample Patterns</h2>
+        <div id="patternHintButtons" class="pattern-hints"></div>
+      </section>
+    </aside>
+
+    <section class="workspace">
+      <section class="builder-section">
+        <div class="section-title">
+          <h2>Properties</h2>
+          <button id="addPropertyButton" type="button">Add property</button>
+        </div>
+        <div id="palette" class="palette"></div>
+        <div id="propertyRows" class="rows"></div>
+      </section>
+
+      <section class="builder-section split">
+        <div>
+          <div class="section-title">
+            <h2>Data Binding</h2>
+            <button id="addFeedButton" type="button">Add feed</button>
+          </div>
+          <label for="bindingId">Binding ID</label>
+          <input id="bindingId" type="text">
+          <div id="feedRows" class="rows compact"></div>
+        </div>
+        <div>
+          <div class="section-title">
+            <h2>Methods and Events</h2>
+            <button id="addMethodButton" type="button">Add method</button>
+            <button id="addEventButton" type="button">Add event</button>
+          </div>
+          <div id="methodRows" class="rows compact"></div>
+          <div id="eventRows" class="rows compact"></div>
+        </div>
+      </section>
+
+      <section class="builder-section">
+        <div class="section-title">
+          <h2>Generated Preview</h2>
+          <button id="copyManifestButton" type="button">Copy manifest</button>
+        </div>
+        <div id="status" class="status" role="status"></div>
+        <pre id="manifestPreview"></pre>
+      </section>
+    </section>
+
+    <aside class="panel">
+      <section class="panel-section">
+        <h2>SAC Export</h2>
+        <button id="downloadManifestButton" type="button">Download widget.json</button>
+        <button id="downloadZipButton" type="button">Download Resource-ZIP</button>
+        <button id="downloadAllButton" type="button">Download both</button>
+        <p>The Resource-ZIP contains root-level JavaScript files only. Upload widget.json first in SAC, then the Resource File ZIP.</p>
+      </section>
+
+      <section class="panel-section">
+        <h2>Generated Files</h2>
+        <ul id="fileList"></ul>
+      </section>
+
+      <section class="panel-section">
+        <h2>Sample Data</h2>
+        <textarea id="sampleDataEditor" spellcheck="false"></textarea>
+      </section>
+    </aside>
+  </main>
+
+  <script id="local-builder-config" type="application/json">
+  {
+    "schema": "sap-sac-widget-local-builder/v1",
+    "runtimeName": "SAC Custom Widget Local Builder",
+    "defaultArtifactMode": "sac-two-file",
+    "outputNames": {
+      "manifest": "widget.json",
+      "resourceZipSuffix": "-resources.zip"
+    },
+    "componentFileNames": {
+      "main": "widget.js",
+      "builder": "builder.js",
+      "styling": "styling.js"
+    },
+    "resourceZipExcludedExtensions": [".html", ".css", ".md", ".json"],
+    "resourceZipExcludedPaths": ["design-runtime/"],
+    "defaults": {
+      "name": "Local Builder Widget",
+      "id": "com.company.localbuilderwidget",
+      "version": "1.0.0",
+      "vendor": "Company Name",
+      "description": "Generated with the local SAC custom widget builder",
+      "license": "MIT",
+      "tag": "com-company-localbuilderwidget",
+      "newInstancePrefix": "LocalBuilderWidget",
+      "icon": "",
+      "includeBuilder": true,
+      "includeStyling": true,
+      "supportsMobile": true,
+      "supportsExport": false,
+      "supportsBookmark": true
+    },
+    "controlPalette": [
+      { "type": "string", "label": "Text input", "propertyType": "string", "default": "Sample text" },
+      { "type": "number", "label": "Number", "propertyType": "number", "default": 12 },
+      { "type": "integer", "label": "Integer", "propertyType": "integer", "default": 1 },
+      { "type": "hexColor", "label": "Hex color string", "propertyType": "string", "default": "#0a6ed1" },
+      { "type": "boolean", "label": "Toggle", "propertyType": "boolean", "default": true },
+      { "type": "select", "label": "Dropdown", "propertyType": "string", "default": "standard", "options": ["standard", "compact", "expanded"] },
+      { "type": "textarea", "label": "Textarea", "propertyType": "string", "default": "Description" },
+      { "type": "slider", "label": "Slider", "propertyType": "integer", "default": 50 },
+      { "type": "group", "label": "Group label", "propertyType": "string", "default": "General" },
+      { "type": "divider", "label": "Divider", "propertyType": "boolean", "default": true }
+    ],
+    "defaultProperties": [
+      {
+        "name": "title",
+        "label": "Title",
+        "type": "string",
+        "control": "string",
+        "default": "Local Builder Widget",
+        "description": "Widget title"
+      },
+      {
+        "name": "primaryColor",
+        "label": "Primary Color",
+        "type": "string",
+        "control": "hexColor",
+        "default": "#0a6ed1",
+        "description": "Primary color as a portable hex string"
+      },
+      {
+        "name": "showValues",
+        "label": "Show Values",
+        "type": "boolean",
+        "control": "boolean",
+        "default": true,
+        "description": "Show measure values"
+      }
+    ],
+    "defaultFeeds": [
+      { "id": "dimensions", "description": "Dimensions", "type": "dimension" },
+      { "id": "measures", "description": "Measures", "type": "mainStructureMember" }
+    ],
+    "sampleRows": [
+      {
+        "dimensions_0": { "id": "north", "label": "North" },
+        "measures_0": { "raw": 128000, "formatted": "128,000" }
+      },
+      {
+        "dimensions_0": { "id": "south", "label": "South" },
+        "measures_0": { "raw": 96000, "formatted": "96,000" }
+      },
+      {
+        "dimensions_0": { "id": "west", "label": "West" },
+        "measures_0": { "raw": 143000, "formatted": "143,000" }
+      }
+    ],
+    "patternHints": [
+      {
+        "id": "data-bound-chart",
+        "label": "Data-bound chart",
+        "description": "Generic line, funnel, pie, Pareto, or bar-style scaffold with one dimension feed and one measure feed.",
+        "lesson": "Most SAP chart samples start with Data Binding plus root-relative component URLs for SAC Resource-ZIP mode.",
+        "mode": "prefill",
+        "prefill": {
+          "bindingId": "dataBinding",
+          "components": { "includeBuilder": false, "includeStyling": false },
+          "supportFlags": { "supportsMobile": true, "supportsExport": false, "supportsBookmark": true },
+          "properties": [
+            { "name": "title", "label": "Title", "type": "string", "control": "string", "default": "Data-bound Chart", "description": "Widget title" },
+            { "name": "primaryColor", "label": "Primary Color", "type": "string", "control": "hexColor", "default": "#0a6ed1", "description": "Primary chart color as a hex string" },
+            { "name": "showValues", "label": "Show Values", "type": "boolean", "control": "boolean", "default": true, "description": "Show measure labels" }
+          ],
+          "feeds": [
+            { "id": "dimensions", "description": "Dimensions", "type": "dimension" },
+            { "id": "measures", "description": "Measures", "type": "mainStructureMember" }
+          ],
+          "methods": [],
+          "events": [
+            { "name": "onDataPointSelect", "description": "Raised when a data point is selected" }
+          ]
+        }
+      },
+      {
+        "id": "kpi-gauge",
+        "label": "KPI / gauge",
+        "description": "Compact KPI, ring, gauge, or half-donut scaffold with threshold-oriented properties.",
+        "lesson": "KPI samples still benefit from Data Binding and simple property-backed thresholds before adding richer panel logic.",
+        "mode": "prefill",
+        "prefill": {
+          "bindingId": "dataBinding",
+          "components": { "includeBuilder": false, "includeStyling": true },
+          "supportFlags": { "supportsMobile": true, "supportsExport": false, "supportsBookmark": true },
+          "properties": [
+            { "name": "title", "label": "Title", "type": "string", "control": "string", "default": "KPI Gauge", "description": "Widget title" },
+            { "name": "primaryColor", "label": "Primary Color", "type": "string", "control": "hexColor", "default": "#247a3d", "description": "Positive or primary KPI color" },
+            { "name": "warningThreshold", "label": "Warning Threshold", "type": "integer", "control": "slider", "default": 70, "description": "Warning threshold percentage" },
+            { "name": "reverseScale", "label": "Reverse Scale", "type": "boolean", "control": "boolean", "default": false, "description": "Reverse threshold interpretation" }
+          ],
+          "feeds": [
+            { "id": "dimensions", "description": "Optional labels", "type": "dimension" },
+            { "id": "measures", "description": "KPI measure", "type": "mainStructureMember" }
+          ],
+          "methods": [],
+          "events": []
+        }
+      },
+      {
+        "id": "flow-hierarchy-chart",
+        "label": "Flow / hierarchy",
+        "description": "Generic Sankey, Sunburst, Tree, or hierarchy scaffold with styling-panel-ready controls.",
+        "lesson": "Flow and hierarchy samples use explicit layout properties, styling components, and deliberate support flags.",
+        "mode": "prefill",
+        "prefill": {
+          "bindingId": "dataBinding",
+          "components": { "includeBuilder": false, "includeStyling": true },
+          "supportFlags": { "supportsMobile": true, "supportsExport": true, "supportsBookmark": true },
+          "properties": [
+            { "name": "title", "label": "Title", "type": "string", "control": "string", "default": "Flow Hierarchy", "description": "Widget title" },
+            { "name": "primaryColor", "label": "Node Color", "type": "string", "control": "hexColor", "default": "#0a6ed1", "description": "Default node color" },
+            { "name": "layoutMode", "label": "Layout Mode", "type": "string", "control": "select", "default": "standard", "description": "Generic layout mode" },
+            { "name": "nodeSize", "label": "Node Size", "type": "integer", "control": "slider", "default": 50, "description": "Relative node size" }
+          ],
+          "feeds": [
+            { "id": "dimensions", "description": "Hierarchy dimensions", "type": "dimension" },
+            { "id": "measures", "description": "Flow or node measure", "type": "mainStructureMember" }
+          ],
+          "methods": [
+            { "name": "getSelectedDataPoint", "description": "Return the last selected data point" }
+          ],
+          "events": [
+            { "name": "onClick", "description": "Raised when a node or data point is clicked" }
+          ]
+        }
+      },
+      {
+        "id": "builder-input-utility",
+        "label": "Builder input utility",
+        "description": "Property-driven input utility scaffold for authored text or parameter-style widgets.",
+        "lesson": "Input-focused samples can skip model feeds and use builder panels, properties, methods, and events instead.",
+        "mode": "prefill",
+        "prefill": {
+          "bindingId": "myDataBinding",
+          "components": { "includeBuilder": true, "includeStyling": false },
+          "supportFlags": { "supportsMobile": true, "supportsExport": false, "supportsBookmark": true },
+          "properties": [
+            { "name": "title", "label": "Title", "type": "string", "control": "string", "default": "Input Utility", "description": "Widget title" },
+            { "name": "text", "label": "Text", "type": "string", "control": "textarea", "default": "Sample input text", "description": "Authored input text" },
+            { "name": "primaryColor", "label": "Primary Color", "type": "string", "control": "hexColor", "default": "#0a6ed1", "description": "Primary color as a hex string" }
+          ],
+          "feeds": [],
+          "methods": [
+            { "name": "setText", "description": "Set the input text from SAC scripting" }
+          ],
+          "events": [
+            { "name": "onTextChange", "description": "Raised when text changes" }
+          ]
+        }
+      },
+      {
+        "id": "widget-addon-reference",
+        "label": "Widget Add-on reference",
+        "description": "Reference-only reminder for tooltip, plot area, and numeric point add-ons.",
+        "lesson": "Widget Add-ons use extensions[] manifests and extension points; use the add-on guide instead of this scaffold exporter.",
+        "mode": "reference-only"
+      },
+      {
+        "id": "build-based-app-reference",
+        "label": "Build-based app reference",
+        "description": "Reference-only reminder for file upload, UI5, React, API, or service-backed widgets.",
+        "lesson": "Build-based widgets require dependency, API, security, tenant, and Resource-ZIP planning outside the no-install local builder.",
+        "mode": "reference-only"
+      }
+    ]
+  }
+  </script>
+  <script src="./builder.js"></script>
+</body>
+</html>

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/server.mjs
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/server.mjs
@@ -25,7 +25,17 @@ function isInside(base, file) {
 function serveFile(req, res) {
   const url = new URL(req.url, protocol + "://" + host);
   const pathname = url.pathname === "/" ? "/index.html" : url.pathname;
-  const candidate = path.normalize(path.join(root, decodeURIComponent(pathname)));
+  let decodedPathname;
+
+  try {
+    decodedPathname = decodeURIComponent(pathname);
+  } catch {
+    res.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+    res.end("bad request");
+    return;
+  }
+
+  const candidate = path.normalize(path.join(root, decodedPathname));
 
   if (!isInside(root, candidate) || !fs.existsSync(candidate) || fs.statSync(candidate).isDirectory()) {
     res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/server.mjs
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/server.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const host = "127.0.0.1";
+const protocol = "http";
+const requestedPort = Number.parseInt(process.env.PORT || "8177", 10);
+
+const mime = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8"
+};
+
+function isInside(base, file) {
+  const relative = path.relative(base, file);
+  return relative === "" || (relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function serveFile(req, res) {
+  const url = new URL(req.url, protocol + "://" + host);
+  const pathname = url.pathname === "/" ? "/index.html" : url.pathname;
+  const candidate = path.normalize(path.join(root, decodeURIComponent(pathname)));
+
+  if (!isInside(root, candidate) || !fs.existsSync(candidate) || fs.statSync(candidate).isDirectory()) {
+    res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    res.end("not found");
+    return;
+  }
+
+  res.writeHead(200, { "content-type": mime[path.extname(candidate)] || "application/octet-stream" });
+  res.end(fs.readFileSync(candidate));
+}
+
+const server = http.createServer(serveFile);
+
+server.listen(requestedPort, host, () => {
+  const address = server.address();
+  console.log("SAC local builder running at " + protocol + "://" + host + ":" + address.port + "/");
+});

--- a/scripts/validate-templates.mjs
+++ b/scripts/validate-templates.mjs
@@ -222,6 +222,271 @@ function validateRuntimeConfig(config, label) {
   }
 }
 
+function assertNoHostedAssetText(text, label) {
+  if (/https?:\/\//i.test(text)) {
+    errors.push(`${label}: local builder template must not contain hosted URLs or remote assets`);
+  }
+}
+
+function validateLocalBuilderConfig(config, label) {
+  if (!config) return;
+  if (config.schema !== "sap-sac-widget-local-builder/v1") {
+    errors.push(`${label}: schema must be sap-sac-widget-local-builder/v1`);
+  }
+  if (config.defaultArtifactMode !== "sac-two-file") {
+    errors.push(`${label}: defaultArtifactMode must be sac-two-file`);
+  }
+  if (!config.outputNames || config.outputNames.manifest !== "widget.json") {
+    errors.push(`${label}: outputNames.manifest must be widget.json`);
+  }
+  if (!config.outputNames || config.outputNames.resourceZipSuffix !== "-resources.zip") {
+    errors.push(`${label}: outputNames.resourceZipSuffix must be -resources.zip`);
+  }
+  const componentFiles = config.componentFileNames || {};
+  for (const [key, expected] of Object.entries({ main: "widget.js", builder: "builder.js", styling: "styling.js" })) {
+    if (componentFiles[key] !== expected) {
+      errors.push(`${label}: componentFileNames.${key} must be ${expected}`);
+    }
+  }
+  const excluded = config.resourceZipExcludedExtensions || [];
+  for (const extension of [".html", ".css", ".md", ".json"]) {
+    if (!excluded.includes(extension)) {
+      errors.push(`${label}: resourceZipExcludedExtensions must include ${extension}`);
+    }
+  }
+
+  const patternHints = config.patternHints;
+  const requiredHints = [
+    "data-bound-chart",
+    "kpi-gauge",
+    "flow-hierarchy-chart",
+    "builder-input-utility",
+    "widget-addon-reference",
+    "build-based-app-reference",
+  ];
+  if (!Array.isArray(patternHints)) {
+    errors.push(`${label}: patternHints must be an array`);
+    return;
+  }
+
+  const seen = new Set();
+  for (const hint of patternHints) {
+    if (!hint || typeof hint !== "object" || Array.isArray(hint)) {
+      errors.push(`${label}: every patternHint must be an object`);
+      continue;
+    }
+    if (!hint.id || typeof hint.id !== "string") {
+      errors.push(`${label}: every patternHint must include a string id`);
+      continue;
+    }
+    if (seen.has(hint.id)) {
+      errors.push(`${label}: duplicate patternHint id ${hint.id}`);
+    }
+    seen.add(hint.id);
+    for (const field of ["label", "description", "lesson", "mode"]) {
+      if (!hint[field] || typeof hint[field] !== "string") {
+        errors.push(`${label}: patternHint ${hint.id} must include string ${field}`);
+      }
+    }
+    if (!["prefill", "reference-only"].includes(hint.mode)) {
+      errors.push(`${label}: patternHint ${hint.id} mode must be prefill or reference-only`);
+    }
+    if (hint.mode === "reference-only" && hint.prefill) {
+      errors.push(`${label}: reference-only patternHint ${hint.id} must not include prefill`);
+    }
+    if (hint.mode === "prefill") {
+      if (!hint.prefill || typeof hint.prefill !== "object" || Array.isArray(hint.prefill)) {
+        errors.push(`${label}: prefill patternHint ${hint.id} must include a prefill object`);
+      } else {
+        if (!Array.isArray(hint.prefill.properties)) {
+          errors.push(`${label}: prefill patternHint ${hint.id} must include properties array`);
+        }
+        if (!Array.isArray(hint.prefill.feeds)) {
+          errors.push(`${label}: prefill patternHint ${hint.id} must include feeds array`);
+        }
+        if (!hint.prefill.components || typeof hint.prefill.components !== "object" || Array.isArray(hint.prefill.components)) {
+          errors.push(`${label}: prefill patternHint ${hint.id} must include components object`);
+        }
+      }
+    }
+  }
+
+  for (const id of requiredHints) {
+    if (!seen.has(id)) {
+      errors.push(`${label}: patternHints missing ${id}`);
+    }
+  }
+}
+
+function validateSapSampleWidgetLessons() {
+  const lessonsFile = path.join(
+    pluginsRoot,
+    "sap-sac-custom-widget",
+    "skills",
+    "sap-sac-custom-widget",
+    "references",
+    "sap-sample-widget-lessons.md",
+  );
+
+  if (!fs.existsSync(lessonsFile)) {
+    errors.push("sap-sac-custom-widget missing references/sap-sample-widget-lessons.md");
+    return;
+  }
+
+  const text = fs.readFileSync(lessonsFile, "utf8");
+  const requiredSamples = [
+    "Custom Pie Chart",
+    "Funnel Chart",
+    "Gauge Grade Chart",
+    "Half Donut Chart",
+    "Integrity Node Files",
+    "Kpi Ring Chart",
+    "Line Chart",
+    "Nested Pie Chart",
+    "Pareto Chart",
+    "Sankey Chart with Styling Panel",
+    "Sunbrust Chart with Styling Panel",
+    "Tree Chart with Styling Panel",
+    "UI5 Gantt Chart",
+    "Widget Add-on Sample",
+    "World Cloud by Input",
+    "bar-gradient-binding",
+    "file-upload-widget-master",
+  ];
+  for (const sample of requiredSamples) {
+    if (!text.includes(sample)) {
+      errors.push(`sap-sac-custom-widget sample lessons missing ${sample}`);
+    }
+  }
+
+  const requiredCaveats = [
+    "Optimized View Mode",
+    "Data Binding",
+    "third-party",
+    "license",
+    "hosting",
+    "path",
+    "extensions[]",
+    "build-based",
+  ];
+  for (const caveat of requiredCaveats) {
+    if (!text.toLowerCase().includes(caveat.toLowerCase())) {
+      errors.push(`sap-sac-custom-widget sample lessons missing caveat '${caveat}'`);
+    }
+  }
+}
+
+function validateSacLocalBuilderTemplate() {
+  const builderRoot = path.join(
+    pluginsRoot,
+    "sap-sac-custom-widget",
+    "skills",
+    "sap-sac-custom-widget",
+    "templates",
+    "local-builder",
+  );
+
+  const requiredFiles = ["index.html", "builder.css", "builder.js", "builder-config.json", "server.mjs"];
+  for (const relativeFile of requiredFiles) {
+    if (!fs.existsSync(path.join(builderRoot, relativeFile))) {
+      errors.push(`sap-sac-custom-widget local builder missing ${relativeFile}`);
+    }
+  }
+  if (requiredFiles.some((relativeFile) => !fs.existsSync(path.join(builderRoot, relativeFile)))) {
+    return;
+  }
+
+  for (const relativeFile of requiredFiles) {
+    const file = path.join(builderRoot, relativeFile);
+    assertNoHostedAssetText(fs.readFileSync(file, "utf8"), `sap-sac-custom-widget local builder ${relativeFile}`);
+  }
+
+  const config = readJsonTemplate(
+    path.join(builderRoot, "builder-config.json"),
+    "sap-sac-custom-widget local builder builder-config.json",
+  );
+  validateLocalBuilderConfig(config, "sap-sac-custom-widget local builder builder-config.json");
+
+  const indexText = fs.readFileSync(path.join(builderRoot, "index.html"), "utf8");
+  const embeddedConfig = (() => {
+    const match = indexText.match(/<script id="local-builder-config" type="application\/json">([\s\S]*?)<\/script>/);
+    if (!match) {
+      errors.push("sap-sac-custom-widget local builder index.html missing local-builder-config JSON script");
+      return null;
+    }
+    try {
+      return JSON.parse(match[1]);
+    } catch (error) {
+      errors.push(`sap-sac-custom-widget local builder embedded config is invalid JSON: ${error.message}`);
+      return null;
+    }
+  })();
+  validateLocalBuilderConfig(embeddedConfig, "sap-sac-custom-widget local builder embedded config");
+  if (config && embeddedConfig && JSON.stringify(config) !== JSON.stringify(embeddedConfig)) {
+    errors.push("sap-sac-custom-widget local builder embedded config must match builder-config.json");
+  }
+
+  if (!indexText.includes('href="./builder.css"')) {
+    errors.push("sap-sac-custom-widget local builder index.html must load ./builder.css");
+  }
+  if (!indexText.includes('src="./builder.js"')) {
+    errors.push("sap-sac-custom-widget local builder index.html must load ./builder.js");
+  }
+  if (!indexText.includes("local-builder-config")) {
+    errors.push("sap-sac-custom-widget local builder index.html must embed local-builder-config JSON");
+  }
+  if (!indexText.includes("patternHintButtons")) {
+    errors.push("sap-sac-custom-widget local builder index.html must expose patternHintButtons UI");
+  }
+
+  const builderJs = fs.readFileSync(path.join(builderRoot, "builder.js"), "utf8");
+  if (!builderJs.includes("widget.json") || !builderJs.includes("-resources.zip")) {
+    errors.push("sap-sac-custom-widget local builder builder.js must default to widget.json plus <slug>-resources.zip downloads");
+  }
+  for (const forbidden of [".html", ".css", ".md", "design-runtime/"]) {
+    if (!builderJs.includes(forbidden)) {
+      errors.push(`sap-sac-custom-widget local builder builder.js must explicitly exclude ${forbidden} from Resource-ZIP output`);
+    }
+  }
+  for (const required of ["renderPatternHints", "applyPatternHint", "patternHints"]) {
+    if (!builderJs.includes(required)) {
+      errors.push(`sap-sac-custom-widget local builder builder.js must include ${required}`);
+    }
+  }
+
+  for (const relativeFile of ["builder.js", "server.mjs"]) {
+    const jsCheck = spawnSync(process.execPath, ["--check", path.join(builderRoot, relativeFile)], { encoding: "utf8" });
+    if (jsCheck.status !== 0) {
+      errors.push(`sap-sac-custom-widget local builder ${relativeFile} failed syntax check: ${(jsCheck.stderr || jsCheck.stdout).trim()}`);
+    }
+  }
+}
+
+function validateSacBuilderPanelTemplate() {
+  const builderPanelFile = path.join(
+    pluginsRoot,
+    "sap-sac-custom-widget",
+    "skills",
+    "sap-sac-custom-widget",
+    "templates",
+    "builder-panel.js",
+  );
+  if (!fs.existsSync(builderPanelFile)) {
+    errors.push("sap-sac-custom-widget missing templates/builder-panel.js");
+    return;
+  }
+  const text = fs.readFileSync(builderPanelFile, "utf8");
+  for (const required of ["customElements.define", "propertiesChanged", "onCustomWidgetBeforeUpdate", "onCustomWidgetAfterUpdate"]) {
+    if (!text.includes(required)) {
+      errors.push(`sap-sac-custom-widget templates/builder-panel.js missing ${required}`);
+    }
+  }
+  const jsCheck = spawnSync(process.execPath, ["--check", builderPanelFile], { encoding: "utf8" });
+  if (jsCheck.status !== 0) {
+    errors.push(`sap-sac-custom-widget templates/builder-panel.js failed syntax check: ${(jsCheck.stderr || jsCheck.stdout).trim()}`);
+  }
+}
+
 async function smokeServeRuntimeFixture(runtimeRoot) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "sap-sac-widget-runtime-"));
   try {
@@ -392,6 +657,9 @@ for (const file of walk(pluginsRoot).filter((item) => repoRelativePath(item).inc
 
 validateHttpsToSftpIflowTemplate();
 await validateSacDesignRuntimeTemplate();
+validateSapSampleWidgetLessons();
+validateSacLocalBuilderTemplate();
+validateSacBuilderPanelTemplate();
 
 if (errors.length > 0) {
   console.error("Template validation failed:");

--- a/scripts/validate-templates.mjs
+++ b/scripts/validate-templates.mjs
@@ -154,6 +154,24 @@ function readJsonTemplate(file, label) {
   }
 }
 
+function canonicalizeJson(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalizeJson(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalizeJson(value[key])]),
+    );
+  }
+  return value;
+}
+
+function semanticJsonEqual(left, right) {
+  return JSON.stringify(canonicalizeJson(left)) === JSON.stringify(canonicalizeJson(right));
+}
+
 function extractEmbeddedRuntimeConfig(indexFile) {
   const text = fs.readFileSync(indexFile, "utf8");
   const match = text.match(/<script id="embedded-runtime-config" type="application\/json">([\s\S]*?)<\/script>/);
@@ -252,6 +270,12 @@ function validateLocalBuilderConfig(config, label) {
   for (const extension of [".html", ".css", ".md", ".json"]) {
     if (!excluded.includes(extension)) {
       errors.push(`${label}: resourceZipExcludedExtensions must include ${extension}`);
+    }
+  }
+  const excludedPaths = config.resourceZipExcludedPaths || [];
+  for (const excludedPath of ["design-runtime/", "local-builder/"]) {
+    if (!excludedPaths.includes(excludedPath)) {
+      errors.push(`${label}: resourceZipExcludedPaths must include ${excludedPath}`);
     }
   }
 
@@ -415,14 +439,14 @@ function validateSacLocalBuilderTemplate() {
       return null;
     }
     try {
-      return JSON.parse(match[1]);
+      return JSON.parse(stripPlaceholders(match[1]));
     } catch (error) {
       errors.push(`sap-sac-custom-widget local builder embedded config is invalid JSON: ${error.message}`);
       return null;
     }
   })();
   validateLocalBuilderConfig(embeddedConfig, "sap-sac-custom-widget local builder embedded config");
-  if (config && embeddedConfig && JSON.stringify(config) !== JSON.stringify(embeddedConfig)) {
+  if (config && embeddedConfig && !semanticJsonEqual(config, embeddedConfig)) {
     errors.push("sap-sac-custom-widget local builder embedded config must match builder-config.json");
   }
 
@@ -443,7 +467,7 @@ function validateSacLocalBuilderTemplate() {
   if (!builderJs.includes("widget.json") || !builderJs.includes("-resources.zip")) {
     errors.push("sap-sac-custom-widget local builder builder.js must default to widget.json plus <slug>-resources.zip downloads");
   }
-  for (const forbidden of [".html", ".css", ".md", "design-runtime/"]) {
+  for (const forbidden of [".html", ".css", ".md", "design-runtime/", "local-builder/"]) {
     if (!builderJs.includes(forbidden)) {
       errors.push(`sap-sac-custom-widget local builder builder.js must explicitly exclude ${forbidden} from Resource-ZIP output`);
     }


### PR DESCRIPTION
## Description
Adds enterprise-safe local SAP Analytics Cloud custom widget builder guidance and templates, plus SAP sample-widget lessons for generation decisions.

## Type of Change
- [ ] New skill
- [ ] Bug fix
- [x] Enhancement to existing skill
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

### For All PRs
- [x] Code follows the project's coding guidelines
- [x] Self-review of changes completed
- [x] Changes are documented appropriately

### For New Skills
- [ ] SKILL.md created with valid YAML frontmatter
- [ ] README.md includes auto-trigger keywords
- [ ] License field set to GPL-3.0
- [ ] Description includes "Use when" scenarios
- [ ] Keywords comprehensive (technologies, use cases, errors)
- [ ] Tested skill discovery with Claude Code/Desktop
- [ ] Ran skill-review for quality verification (if available)

### For Skill Enhancements
- [x] Package versions verified as current
- [x] Breaking changes documented
- [x] Examples tested
- [x] Known issues updated

### For Documentation
- [x] Links verified
- [x] Grammar/spelling checked
- [ ] Screenshots updated (if applicable)

## Related Issues


## Testing
- `node --check plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/builder.js`
- `node --check plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/local-builder/server.mjs`
- `node --check plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/builder-panel.js`
- `node scripts/validate-bundled-resources.mjs`
- `node scripts/validate-packaging-hygiene.mjs`
- `node scripts/validate-command-contracts.mjs`
- `node scripts/validate-reference-provenance.mjs`
- `node scripts/validate-public-claims.mjs`
- `node scripts/validate-templates.mjs` fails only because `xmllint` is unavailable for an unrelated iFlow XML template check.

## Additional Notes
- Live SAC tenant import/runtime validation remains pending.
- `gh` is not installed locally; this PR was created via GitHub API using Git Credential Manager credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a no-install, browser-based Local Builder for SAC custom widgets, including widget.json download, Resource-ZIP export, sample data editing, and live manifest preview.
  * Expanded generation to scaffold optional local builder and browser design-runtime components, guided by sample-informed pattern hints.
* **Documentation**
  * Updated plugin README and reference guides to cover the Local Builder workflow, export/import rules, and the “SAP Sample Widget Lessons” starting-point guidance.
* **Bug Fixes**
  * Strengthened template validation to detect missing/invalid template assets, configuration mismatches, unsafe hosted URLs, and malformed local builder definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->