### PR TITLE
feat: add evidence-aware SAC widget discovery

### DIFF
--- a/plugins/sap-sac-custom-widget/commands/widget-generate.md
+++ b/plugins/sap-sac-custom-widget/commands/widget-generate.md
@@ -15,7 +15,7 @@ argument-hint: [widget-name]
 
 ## Output Contract
 
-Return data-aware suggestions, the planned widget structure, SAP sample lesson fit, file snippets or files to create/change, local-builder/design-runtime inclusion notes, security/accessibility notes, and confirmation points before writes. Default to snippets/plans; generate files only when the user explicitly requests generation and confirms a target directory.
+Return role-aware suggestions, the Widget Brief, planned widget structure, SAP sample lesson fit, file snippets or files to create/change, local-builder/design-runtime inclusion notes, security/accessibility notes, and confirmation points before writes. Default to snippets/plans; generate files only when the user explicitly requests generation and confirms a target directory.
 
 
 # SAC Custom Widget Generator Command
@@ -44,25 +44,32 @@ When invoked without `--quick`, ask the user these questions:
    - Reverse domain notation (e.g., "com.company.mychart")
    - Default: Generate from widget name
 
-3. **Business Goal and Chart Intent**
-   - Decision or insight the widget should support
-   - Ask whether to recommend chart types or use a fixed chart type
-   - Consult `references/sap-sample-widget-lessons.md` when the request resembles a chart, KPI/gauge, flow/hierarchy, input utility, Widget Add-On, or build-based app
+3. **Widget Role**
+   - Options: Table/chart/KPI, UI control/navigation (menu, sidebar, filter), Hybrid, Widget Add-on, Build-based integration
+   - Use `references/widget-discovery-intake.md` to select the correct route before asking about data or implementation details
+   - Consult `references/sap-sample-widget-lessons.md` for the nearest SAP sample family and caveats
 
-4. **Sample Data or Schema**
-   - Columns, dimensions, measures, dates, versions, and filters
-   - Ask for representative CSV/schema when using BW live models or prompt-only generation
+4. **Data-Source Mode**
+   - Options: SAC-bound, Property/config-supplied, No data
+   - Ask for dimensions, measures/key figures, dates, versions, filters, and feed order only for SAC-bound widgets
+   - For No data widgets, use the minimal manifest/property/event pattern and omit `dataBindings` unless the runtime consumes SAC model data
 
-5. **Data Binding**
-   - "Does your widget need to bind to SAC model data?"
-   - Options: Yes (dimensions + measures), Yes (measures only), No
-   - Preserve feed order exactly in generated code
+5. **Business Goal and Interaction Intent**
+   - For a table/chart/KPI: decision or insight, aggregation/formatting rules, and empty/error state
+   - For a menu, sidebar, or filter: item hierarchy, labels/icons, active/disabled states, commands, navigation/filter actions, permissions, keyboard behavior, and mobile layout
+   - For a hybrid: define the interaction contract first, then request only the model state it displays or controls
 
-6. **Components**
+6. **Evidence and Data Contract**
+   - Invite user-provided screenshots, PDFs, images, brand guides, sanitized CSV/schema, and model/story evidence
+   - Confirm technical IDs, feed mappings, asset rights, licenses, and navigation destinations before code generation
+   - For SAC-bound widgets, request semantic field roles, aggregation/formatting, expected data volume, and exact feed order
+   - For property/config-supplied or No data widgets, request property defaults, validation, and authoring behavior instead of dimensions or key figures
+
+7. **Components**
    - "Which components do you need?"
    - Options: Main only, Main + Styling Panel, Main + Builder Panel, All three
 
-7. **Local Builder**
+8. **Local Builder**
    - "Include the local SAC widget builder scaffold?"
    - Default: Yes for local or enterprise environments
    - Copy `templates/local-builder/` into generated packages when the user wants a no-install browser builder for metadata, properties, feeds, methods, events, and SAC artifact export
@@ -70,22 +77,29 @@ When invoked without `--quick`, ask the user these questions:
 
 ### Optional Questions
 
-8. **Third-Party Library**
+9. **Third-Party Library**
    - "Will you integrate a charting library?"
    - Options: ECharts, D3.js, Chart.js, None
 
-9. **Brand and Visual Direction**
-   - Brand logo/icon URLs, colors, and style preference
-   - Use brand assets only when they are trusted and accessible to SAC
+10. **Brand and Visual Direction**
+   - Brand logo/icon URLs, colors, style preference, or user-provided screenshots/PDFs/images
+   - Use visual evidence to inform layout, hierarchy, and design tokens; do not treat it as proof of asset rights or technical metadata
+   - Use brand assets only when rights, source, and SAC accessibility are confirmed
    - If provided, map icon URL to manifest `icon` and logo URL to a `brandLogoUrl` property
 
-10. **Deployment and Reuse Target**
+11. **Optional Hosted Exploration**
+   - Offer [Custom Widget Builder](https://www.custom-widgets.de/custom-widget-builder) or [live demo](https://www.custom-widgets.de/demo) only when the user permits public-web use for a desktop, non-sensitive visual prototype
+   - Keep `templates/local-builder/` as the enterprise-safe default
+   - Never send confidential screenshots, PDFs, tenant details, code, data, credentials, or internal assets to hosted tools
+   - Treat downloaded packages as untrusted external artifacts and validate them locally before SAC import
+
+12. **Deployment and Reuse Target**
    - SAC-hosted files, external HTTPS host, or widget server
    - SAC ZIP resource upload, if the tenant flow requires uploading a ZIP after `widget.json`
    - Confirm this before deciding whether CSS/HTML can be separate resource files or must be embedded in JavaScript templates
    - Ask whether the widget should be reusable inside an SAC composite
 
-11. **Initial Properties**
+13. **Initial Properties**
    - "What properties should be configurable?"
    - Default: title (string), color (Color)
 
@@ -239,6 +253,8 @@ Static no-install builder scaffold with:
 
 The local builder is for scaffold generation and SAC artifact export. It is not a live SAC runtime and does not replace `design-runtime/` preview checks.
 
+For a user-approved public-web, non-sensitive desktop prototype, optionally suggest the [Custom Widget Builder](https://www.custom-widgets.de/custom-widget-builder) or [live demo](https://www.custom-widgets.de/demo). Keep the local builder as the enterprise-safe default and treat hosted exports as untrusted external artifacts that need normal local validation.
+
 ### 6. sample-informed pattern hints
 
 When the request maps to a SAP sample family, document the chosen hint and caveat:
@@ -284,6 +300,7 @@ Offer `templates/local-builder/` as the default local enterprise option when a u
 - Use `node server.mjs` from `local-builder/` only as a loopback fallback if direct `file://` use is blocked.
 - Treat local builder output as generated scaffolding; still validate with `/widget-validate`, JavaScript syntax checks, Resource-ZIP inspection, and SAC tenant import when available.
 - Use the built-in sample-informed pattern hints only as generic prefill. Reference-only hints for Widget Add-ons and build-based apps should redirect to planning guidance rather than generating unsupported scaffolds.
+- For a public-web, non-sensitive desktop prototype, optionally suggest the hosted builder/demo links from the intake flow. Never transfer confidential attachments or tenant material, and validate any hosted export locally before import.
 
 ## Browser Design Runtime
 
@@ -545,15 +562,16 @@ After files are generated, provide:
 When this command is invoked:
 
 1. If widget name provided, use it; otherwise ask
-2. Ask interactive questions based on mode
-3. For prompt-driven requests, return suggestions-stage JSON and wait for the selected option before code generation
-4. Generate widget.json with all selections
-5. Generate widget.js with matching implementation
-6. Generate additional component files if selected
-7. Use `references/sap-sample-widget-lessons.md` to identify the nearest sample family, required caveats, and whether the request should stay on the normal custom-widget path, route to Widget Add-on guidance, or require build-based app planning
-8. Copy `templates/local-builder/` into the generated package by default for local/enterprise generation, unless the user explicitly declines it
-9. Copy `templates/design-runtime/` into the generated package and populate its sidecar config for the generated widget
-10. Verify naming, data binding order, sequential result indices, generated-code compatibility rules, local builder export naming, Resource-ZIP exclusions, sample-informed caveats, and runtime sidecar paths that use browser URL `/` separators
-11. If and only if the user confirmed a target directory, write files there; otherwise return snippets and the proposed file tree, including `local-builder/` and `design-runtime/`
-12. Provide post-generation instructions, including the local builder, sample lesson caveats, Ready for SAC Install, and Composite Readiness blocks
-13. Suggest running `/widget-validate`, opening `local-builder/index.html` for scaffold/export edits, and opening `design-runtime/index.html` for preview verification
+2. Classify the widget role and data-source mode, then gather the role-appropriate evidence described in `references/widget-discovery-intake.md`
+3. Return a Widget Brief with evidence, data/no-data contract, interactions, properties, brand rules, sensitivity, assumptions, and confirmation questions before code generation
+4. For prompt-driven requests, return suggestions-stage JSON and wait for the selected option before code generation
+5. Generate widget.json with all selections; omit `dataBindings` for a pure UI widget unless it consumes SAC model data
+6. Generate widget.js with matching implementation
+7. Generate additional component files if selected
+8. Use `references/sap-sample-widget-lessons.md` to identify the nearest sample family, required caveats, and whether the request should stay on the normal custom-widget path, route to Widget Add-on guidance, or require build-based app planning
+9. Copy `templates/local-builder/` into the generated package by default for local/enterprise generation, unless the user explicitly declines it
+10. Copy `templates/design-runtime/` into the generated package and populate its sidecar config for the generated widget
+11. Verify naming, data binding order when present, sequential result indices, generated-code compatibility rules, local builder export naming, Resource-ZIP exclusions, sample-informed caveats, and runtime sidecar paths that use browser URL `/` separators
+12. If and only if the user confirmed a target directory, write files there; otherwise return snippets and the proposed file tree, including `local-builder/` and `design-runtime/`
+13. Provide post-generation instructions, including the local builder, sample lesson caveats, Ready for SAC Install, and Composite Readiness blocks
+14. Suggest running `/widget-validate`, opening `local-builder/index.html` for scaffold/export edits, and opening `design-runtime/index.html` for preview verification

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/SKILL.md
@@ -34,6 +34,7 @@ allowed-tools:
 ## Table of Contents
 - [Overview](#overview)
 - [AI-Assisted Generation](#ai-assisted-generation)
+- [Widget Discovery and Evidence Intake](#widget-discovery-and-evidence-intake)
 - [Local Custom Widget Builder](#local-custom-widget-builder)
 - [SAP Sample Widget Lessons](#sap-sample-widget-lessons)
 - [Browser Design Runtime](#browser-design-runtime)
@@ -70,13 +71,19 @@ This skill enables development of custom widgets for SAP Analytics Cloud (SAC). 
 
 ## AI-Assisted Generation
 
-For prompt-driven widget creation, first suggest 2-3 data-aware widget options, then generate the selected complete package. Keep AI-generated code SAC-compatible, preserve data-binding order, and validate/repair before import. See **`references/ai-assisted-composite-generation.md`** for output contracts, RAG context patterns, brand styling, and composite caveats.
+For prompt-driven widget creation, first classify the widget role and data-source mode, then suggest 2-3 role-aware options before generating the selected complete package. Keep AI-generated code SAC-compatible, preserve data-binding order when used, and validate/repair before import. See **`references/ai-assisted-composite-generation.md`** for output contracts, RAG context patterns, brand styling, and composite caveats.
+
+---
+
+## Widget Discovery and Evidence Intake
+
+Before generating a table, chart, KPI, menu, sidebar, filter, or hybrid control, select both its widget role and data-source mode. Request dimensions, measures/key figures, dates, versions, filters, and feed order only for SAC-bound widgets. For pure UI controls, collect interaction, navigation, state, method/event, accessibility, and responsive-layout requirements instead. Accept user-provided screenshots, PDFs, images, brand guides, and sanitized data as evidence, but confirm technical IDs, feed mappings, asset rights, and licenses before code generation. See **`references/widget-discovery-intake.md`** for the Widget Brief, evidence boundaries, and hosted-tool safeguards.
 
 ---
 
 ## Local Custom Widget Builder
 
-For enterprise or locked-down local environments, offer **`templates/local-builder/`** as the standard no-install scaffold builder. It runs as static HTML/CSS/vanilla JavaScript, avoids public CDNs and external packages, and exports SAC upload artifacts as two separate downloads: `widget.json` and a Resource-ZIP containing only root-level component JavaScript files. Use Node's `server.mjs` fallback when direct `file://` use is blocked. See **`references/local-builder-workflow.md`** for builder boundaries, export rules, and validation checks.
+For enterprise or locked-down local environments, offer **`templates/local-builder/`** as the standard no-install scaffold builder. It runs as static HTML/CSS/vanilla JavaScript, avoids public CDNs and external packages, and exports SAC upload artifacts as two separate downloads: `widget.json` and a Resource-ZIP containing only root-level component JavaScript files. Use Node's `server.mjs` fallback when direct `file://` use is blocked. When a user explicitly permits public-web use for a non-sensitive desktop prototype, optionally suggest the [Custom Widget Builder](https://www.custom-widgets.de/custom-widget-builder) or [live demo](https://www.custom-widgets.de/demo); never send tenant material or trust its exports without local validation. See **`references/local-builder-workflow.md`** for builder boundaries, export rules, hosted-tool safeguards, and validation checks.
 
 ---
 
@@ -449,6 +456,7 @@ See **`references/widget-addon-guide.md`** for complete implementation.
 12. **`references/browser-design-runtime.md`** - Non-SAP browser preview runtime, sidecar config, and agent iteration export
 13. **`references/css-and-styling-compliance.md`** - SAP Help-backed CSS, theme, Shadow DOM, and packaging guidance for generated widgets
 14. **`references/sac-import-packaging-lessons.md`** - SAC-hosted Resource-ZIP upload sequence, URL rules, ZIP hygiene, builder/tree state rules, self-contained component checks, final-artifact tests, and SAC error triage
+15. **`references/widget-discovery-intake.md`** - Widget role/data-source selection, attachment intake, Widget Brief, and hosted-tool safeguards
 
 ---
 

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/local-builder-workflow.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/local-builder-workflow.md
@@ -6,12 +6,13 @@ Use this reference when a user wants a local SAC custom widget builder for enter
 
 1. [Purpose](#purpose)
 2. [Boundary](#boundary)
-3. [Generated Package Shape](#generated-package-shape)
-4. [Builder Controls](#builder-controls)
-5. [Export Contract](#export-contract)
-6. [Usage Workflow](#usage-workflow)
-7. [Validation Checklist](#validation-checklist)
-8. [Source](#source)
+3. [Optional Hosted Exploration](#optional-hosted-exploration)
+4. [Generated Package Shape](#generated-package-shape)
+5. [Builder Controls](#builder-controls)
+6. [Export Contract](#export-contract)
+7. [Usage Workflow](#usage-workflow)
+8. [Validation Checklist](#validation-checklist)
+9. [Source](#source)
 
 ---
 
@@ -30,6 +31,12 @@ Use:
 - `local-builder/` for scaffold generation and `widget.json` plus Resource-ZIP export.
 - `design-runtime/` for local preview, scenario switching, design-token tuning, sample data, and agent iteration export.
 - Real SAC tenant import for final truth.
+
+## Optional Hosted Exploration
+
+`templates/local-builder/` remains the enterprise-safe default for scaffold generation and SAC artifact export. Suggest the hosted [Custom Widget Builder](https://www.custom-widgets.de/custom-widget-builder) or [live demo](https://www.custom-widgets.de/demo) only when the user explicitly permits public-web use for a desktop, non-sensitive visual prototype.
+
+Do not send confidential screenshots, PDFs, tenant details, code, data, credentials, or internal assets to the hosted sites. They are feature-shape references, not live SAC runtime evidence. Treat downloads from them as untrusted external artifacts: validate the manifest and JavaScript locally, inspect the Resource-ZIP, and test import/runtime behavior in a real SAC tenant.
 
 ## Generated Package Shape
 
@@ -137,5 +144,5 @@ Before delivering a package generated through the local builder:
 
 ## Source
 
-- External feature-shape reference: `custom-widgets.de/custom-widget-builder`
+- External feature-shape references: https://www.custom-widgets.de/custom-widget-builder and https://www.custom-widgets.de/demo
 - SAP sample lesson reference: `references/sap-sample-widget-lessons.md`

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/widget-discovery-intake.md
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/references/widget-discovery-intake.md
@@ -1,0 +1,77 @@
+# Widget Discovery Intake
+
+Sources:
+- User-approved SAC widget discovery requirements.
+- Feature-shape references: [Custom Widget Builder](https://www.custom-widgets.de/custom-widget-builder) and [live demo](https://www.custom-widgets.de/demo).
+
+Use this reference before generating a SAC custom widget from a prompt, screenshot, PDF, image, data extract, or existing story. Classify the widget first. Do not assume that every widget is a chart or requires SAC model data.
+
+## Decision Order
+
+1. Select the widget role.
+2. Select the data-source mode.
+3. Gather only the evidence needed for that combination.
+4. Return a Widget Brief with assumptions and questions that need confirmation before code generation.
+
+## Widget Roles
+
+### Table, Chart, and KPI Widgets
+
+Use this role for data tables, charts, scorecards, gauges, progress bars, and other displays whose primary purpose is to present values. Ask what decision the story user should make, how values are aggregated and formatted, and how empty, partial, and error data should appear.
+
+### UI Controls and Navigation
+
+Use this role for a menu, sidebar, button bar, filter control, navigation surface, or other interaction-first widget. Ask for item hierarchy, labels, icons, active and disabled states, commands, navigation or filter actions, permissions, events, methods, keyboard behavior, and mobile layout. Do not ask for dimensions or key figures unless the control displays or derives them.
+
+### Hybrid Widgets
+
+Use this role when a control also displays a small amount of model-driven state, such as a selected member, count, status, or badge. Define the interaction contract first, then request only the model fields that the UI actually reads or changes.
+
+### Widget Add-Ons
+
+Use the Widget Add-on route when the request extends an existing SAC chart area, tooltip, or numeric point. Consult `references/widget-addon-guide.md`; do not treat an add-on as a normal top-level widget.
+
+### Build-Based Integrations
+
+Use this route for UI5/React, file upload, service/API, authentication, or dependency-heavy work. Plan the build output, licenses, security, tenant trust, and Resource-ZIP contents before generating code. Do not route these requests through the no-install local builder.
+
+## Data-Source Modes
+
+### SAC-bound
+
+Use SAC-bound mode when the widget consumes SAC model result sets. Request a representative schema or sanitized CSV, semantic dimensions, measures or key figures, dates, versions, filters, aggregation and formatting rules, expected data volume, and exact feed order. Confirm technical IDs and binding names from the story or model metadata before generating a manifest.
+
+### Property/config-supplied
+
+Use property/config-supplied mode when the story author configures labels, items, values, or static JSON through widget properties. Define property types, defaults, validation, and builder/styling-panel needs. Do not add SAC data bindings merely because the widget displays information.
+
+### No data
+
+Use no-data mode for pure menus, sidebars, navigation, and static interaction surfaces. Generate the minimal manifest/property/event pattern and omit `dataBindings` unless the runtime actually consumes SAC model data. Document actions and state transitions rather than inventing dimensions or feeds.
+
+## Evidence Intake
+
+Accept user-provided evidence only. Ask what each attachment should influence: layout, behavior, data mapping, or brand styling.
+
+- **screenshots**: infer visible layout, labels, hierarchy, states, responsive behavior, and visual tokens. Confirm technical IDs, feed mappings, and interaction behavior separately because they are not reliably visible.
+- **PDFs and images**: use design systems, screenshots, and brand guides to infer colors, typography, spacing, icon treatment, and logo placement. Confirm that logos/assets are licensed and available to the target SAC hosting path before embedding them.
+- **Data extracts and model evidence**: use a schema, CSV, or story/model screenshot to identify candidate dimensions, measures, dates, versions, and filters. Redact customer data and confirm fields, aggregation, and feed order before implementation.
+- **Existing source or exported artifacts**: inspect as input, but do not copy third-party code, tenant URLs, secrets, or license-restricted assets without explicit approval.
+
+Do not treat OCR-like text or visual inference as authoritative. Record uncertain labels, technical IDs, asset ownership, and navigation destinations in the Widget Brief for user confirmation.
+
+## Widget Brief
+
+Before code generation, return a concise brief containing:
+
+- Widget role and data-source mode.
+- Audience, business decision or task, and story placement.
+- Evidence received, intended use, source, and sensitivity classification.
+- Data contract, or an explicit no-data declaration.
+- Properties, methods, events, interactions, permissions, and responsive/accessibility requirements.
+- Brand rules and confirmed asset hosting/license status.
+- Assumptions, missing technical IDs, feed mappings, and confirmation questions.
+
+## Hosted Exploration Boundary
+
+The hosted builder and demo are optional desktop-only visual references. Suggest them only after the user permits public-web use and confirms that the prototype uses non-sensitive, sanitized inputs. Never send confidential screenshots, PDFs, tenant details, code, data, credentials, or internal assets to those sites. Treat any downloaded package as an untrusted external artifact: validate it locally, inspect its Resource-ZIP, and test it in an SAC tenant before relying on it.

--- a/scripts/validate-templates.mjs
+++ b/scripts/validate-templates.mjs
@@ -400,6 +400,91 @@ function validateSapSampleWidgetLessons() {
   }
 }
 
+function validateSacWidgetDiscoveryGuidance() {
+  const skillRoot = path.join(
+    pluginsRoot,
+    "sap-sac-custom-widget",
+    "skills",
+    "sap-sac-custom-widget",
+  );
+  const referenceFile = path.join(skillRoot, "references", "widget-discovery-intake.md");
+  const skillFile = path.join(skillRoot, "SKILL.md");
+  const commandFile = path.join(pluginsRoot, "sap-sac-custom-widget", "commands", "widget-generate.md");
+  const localBuilderWorkflowFile = path.join(skillRoot, "references", "local-builder-workflow.md");
+
+  if (!fs.existsSync(referenceFile)) {
+    errors.push("sap-sac-custom-widget missing references/widget-discovery-intake.md");
+    return;
+  }
+
+  const referenceText = fs.readFileSync(referenceFile, "utf8");
+  const requiredReferenceTerms = [
+    "Table, Chart, and KPI Widgets",
+    "UI Controls and Navigation",
+    "Hybrid Widgets",
+    "Widget Add-Ons",
+    "Build-Based Integrations",
+    "SAC-bound",
+    "Property/config-supplied",
+    "No data",
+    "Widget Brief",
+    "screenshots",
+    "PDFs",
+    "dimensions",
+    "key figures",
+    "feed order",
+    "technical IDs",
+    "licenses",
+    "sensitive",
+  ];
+  for (const term of requiredReferenceTerms) {
+    if (!referenceText.includes(term)) {
+      errors.push(`sap-sac-custom-widget discovery intake missing '${term}'`);
+    }
+  }
+
+  if (!fs.existsSync(skillFile)) {
+    errors.push("sap-sac-custom-widget missing SKILL.md for discovery guidance");
+  } else {
+    const skillText = fs.readFileSync(skillFile, "utf8");
+    for (const term of ["Widget Discovery and Evidence Intake", "references/widget-discovery-intake.md"]) {
+      if (!skillText.includes(term)) {
+        errors.push(`sap-sac-custom-widget SKILL.md discovery guidance missing '${term}'`);
+      }
+    }
+  }
+
+  if (!fs.existsSync(commandFile)) {
+    errors.push("sap-sac-custom-widget missing commands/widget-generate.md for discovery guidance");
+  } else {
+    const commandText = fs.readFileSync(commandFile, "utf8");
+    for (const term of ["Widget Role", "Data-Source Mode", "No data", "screenshots", "PDFs", "menu", "sidebar"]) {
+      if (!commandText.includes(term)) {
+        errors.push(`sap-sac-custom-widget widget-generate discovery guidance missing '${term}'`);
+      }
+    }
+  }
+
+  if (!fs.existsSync(localBuilderWorkflowFile)) {
+    errors.push("sap-sac-custom-widget missing references/local-builder-workflow.md for hosted-builder guidance");
+  } else {
+    const workflowText = fs.readFileSync(localBuilderWorkflowFile, "utf8");
+    const requiredHostedTerms = [
+      "https://www.custom-widgets.de/custom-widget-builder",
+      "https://www.custom-widgets.de/demo",
+      "public-web",
+      "non-sensitive",
+      "enterprise-safe default",
+      "untrusted external artifacts",
+    ];
+    for (const term of requiredHostedTerms) {
+      if (!workflowText.includes(term)) {
+        errors.push(`sap-sac-custom-widget local builder workflow hosted-builder guidance missing '${term}'`);
+      }
+    }
+  }
+}
+
 function validateSacLocalBuilderTemplate() {
   const builderRoot = path.join(
     pluginsRoot,
@@ -682,6 +767,7 @@ for (const file of walk(pluginsRoot).filter((item) => repoRelativePath(item).inc
 validateHttpsToSftpIflowTemplate();
 await validateSacDesignRuntimeTemplate();
 validateSapSampleWidgetLessons();
+validateSacWidgetDiscoveryGuidance();
 validateSacLocalBuilderTemplate();
 validateSacBuilderPanelTemplate();
 


### PR DESCRIPTION
## Summary

- Adds evidence-aware SAC widget discovery for tables, charts, KPIs, menus, sidebars, filters, and hybrid widgets.
- Adds role/data-source intake for SAC-bound, property/config-supplied, and no-data widgets.
- Adds safe guidance for screenshots, PDFs, images, brand material, and optional hosted builder/demo exploration.
- Extends template validation to protect the new skill guidance.

## Testing

- Passed syntax, command contract, reference provenance, public claims, bundled resources, packaging hygiene, and whitespace checks.
- validate-templates.mjs reaches only the known unrelated xmllint blocker for iFlow XML validation.
- Live SAC tenant import/runtime validation remains pending.

## Merge

Normal merge commit requested. CI is intentionally not being awaited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added role-aware guidance for discovering, planning, and generating SAC custom widgets.
  * Expanded intake steps for widget roles, data sources, evidence, components, branding, deployment, and initial properties.
  * Added a new reference for evidence collection and widget briefing.
  * Clarified local builder workflows and optional hosted exploration, including safeguards for sensitive information and untrusted downloads.
  * Documented staged generation, validation, and conditional file output workflows.

* **Tests**
  * Added validation coverage for the new widget discovery and safety guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->