### PR TITLE
chore(security): add CodeQL analysis and Dependabot

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -46,6 +46,23 @@ If you discover a security vulnerability in any skill, please report it by:
 - ✅ Use latest stable package versions
 - ✅ Document known security considerations
 
+## Automated Security Scanning
+
+This repository is covered by two free GitHub features for public repos (no paid Advanced Security license required):
+
+### CodeQL (Static Analysis)
+- Workflow: [`.github/workflows/codeql.yml`](../workflows/codeql.yml) · Config: [`.github/codeql/codeql-config.yml`](../codeql/codeql-config.yml)
+- Languages analyzed: **JavaScript/TypeScript**, **Python**, and **Java**.
+- Runs on every push/PR to `main` that touches source code (content-only changes are ignored), plus a **weekly scheduled** scan to catch newly-released queries.
+- Results appear in the repository's **Security → Code scanning alerts** tab.
+- Note: Java analysis runs without a build (`build-mode: none`) because the repo has no Maven/Gradle build, so results are best-effort for the Eclipse plugin source.
+
+### Dependabot (Dependency + Action Updates)
+- Config: [`.github/dependabot.yml`](../dependabot.yml)
+- Surfaces vulnerability advisories and opens PRs for outdated dependencies (npm) and pinned GitHub Actions, grouped weekly to reduce review load.
+
+Findings from either tool are triaged like any other reported vulnerability (see *Reporting a Vulnerability* above).
+
 ## Known Security Considerations
 
 ### API Keys & Credentials

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -51,14 +51,14 @@ If you discover a security vulnerability in any skill, please report it by:
 This repository is covered by two free GitHub features for public repos (no paid Advanced Security license required):
 
 ### CodeQL (Static Analysis)
-- Workflow: [`.github/workflows/codeql.yml`](../workflows/codeql.yml) · Config: [`.github/codeql/codeql-config.yml`](../codeql/codeql-config.yml)
+- Workflow: [`.github/workflows/codeql.yml`](workflows/codeql.yml) · Config: [`.github/codeql/codeql-config.yml`](codeql/codeql-config.yml)
 - Languages analyzed: **JavaScript/TypeScript**, **Python**, and **Java**.
 - Runs on every push/PR to `main` that touches source code (content-only changes are ignored), plus a **weekly scheduled** scan to catch newly-released queries.
 - Results appear in the repository's **Security → Code scanning alerts** tab.
 - Note: Java analysis runs without a build (`build-mode: none`) because the repo has no Maven/Gradle build, so results are best-effort for the Eclipse plugin source.
 
 ### Dependabot (Dependency + Action Updates)
-- Config: [`.github/dependabot.yml`](../dependabot.yml)
+- Config: [`.github/dependabot.yml`](dependabot.yml)
 - Surfaces vulnerability advisories and opens PRs for outdated dependencies (npm) and pinned GitHub Actions, grouped weekly to reduce review load.
 
 Findings from either tool are triaged like any other reported vulnerability (see *Reporting a Vulnerability* above).

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,18 @@
+# CodeQL runtime configuration — controls what gets *analyzed* (distinct from the
+# paths-ignore on the workflow triggers, which only controls whether the run starts).
+# Docs: https://docs.github.com/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
+
+name: "sap-skills CodeQL config"
+
+# Exclude generated, vendored, and fixture content from analysis.
+# node_modules is already gitignored, but listing it is defense-in-depth for local
+# builds that may leave artifacts behind. dist/ is the esbuild bundle output of
+# the sap-bw-query MCP server (a generated copy of mcp/src/, not source).
+paths-ignore:
+  - node_modules
+  - "plugins/sap-bw-query/mcp/dist"
+  - "tests/fixtures"
+  - "**/*.min.js"
+  - "**/*.min.css"
+  - "**/vendor"
+  - "**/third_party"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# Dependabot keeps dependencies and pinned GitHub Actions current.
+# Combined with CodeQL (see .github/workflows/codeql.yml) this gives the repo
+# both dependency-vulnerability alerting and static analysis.
+#
+# main is protected (requires @secondsky review on every PR), so updates are
+# grouped to minimize PR noise while still surfacing security advisories
+# individually when they occur.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+  # GitHub Actions used in workflows. Keeps checkout/codeql-action/setup-node
+  # (and the rest) patched — security-relevant since these run with secrets.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions:
+        patterns:
+          - "actions/*"
+          - "github/*"
+          - "github/codeql-action"
+
+  # Root devDependencies — validation/audit tooling only (no runtime deps here).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    labels:
+      - dependencies
+      - npm
+    groups:
+      npm-dev:
+        update-types:
+          - minor
+          - patch
+
+  # The sap-bw-query MCP server — the only real runtime dependency
+  # (@modelcontextprotocol/sdk). Kept separate from root so its updates are
+  # reviewed independently.
+  - package-ecosystem: npm
+    directory: /plugins/sap-bw-query/mcp
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    labels:
+      - dependencies
+      - npm
+      - sap-bw-query

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,84 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "**/*.json"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - "**/*.txt"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "**/*.json"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - "**/*.txt"
+  schedule:
+    # Weekly — Monday 05:30 UTC. Catches newly-published CodeQL queries and
+    # analyzes the default branch even when no PRs touch source code.
+    - cron: "30 5 * * 1"
+
+# Cancel superseded runs on the same ref to save runner minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege permissions for CodeQL.
+# security-events: write is required to upload the SARIF results.
+# actions: read is required for CodeQL to inspect workflow runs.
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Primary surface: the sap-bw-query MCP server (auth/secrets/connections),
+          # scripts/*.mjs, tests, and per-plugin hooks.
+          - language: javascript-typescript
+            build-mode: none
+          # Validator hooks (plugins/*/hooks/validator.py) and sap-rpt1 ML scripts.
+          - language: python
+            build-mode: none
+          # Eclipse RCP plugin source (plugins/sap-bw-query/eclipse/...).
+          # build-mode: none because the repo has no Maven/Gradle build. Caveat:
+          # accuracy is reduced ("Good" not "Best") and generated code is not
+          # analyzed. Remove this matrix entry if it proves too noisy.
+          - language: java
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      # analyze@v4 builds the database, runs the queries, and uploads SARIF to
+      # the Security tab — no separate upload-sarif step is needed (that action
+      # is only for results produced by external tools).
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,9 @@ on:
     # Weekly — Monday 05:30 UTC. Catches newly-published CodeQL queries and
     # analyzes the default branch even when no PRs touch source code.
     - cron: "30 5 * * 1"
+  # Manual trigger — useful to run analysis on demand (e.g. after enabling,
+  # before the first scheduled run, or after a config change).
+  workflow_dispatch:
 
 # Cancel superseded runs on the same ref to save runner minutes.
 concurrency:


### PR DESCRIPTION
## Summary

Sets up GitHub Advanced Security scanning for `secondsky/sap-skills`. As a **public repo**, CodeQL and Dependabot are **free** — no paid GHAS license required.

The repo currently has strong *governance* CI (structure, frontmatter, schema, link validation) but **no SAST and no Dependabot config**. This PR adds both as net-new capabilities.

## What's added

### `.github/workflows/codeql.yml` — CodeQL static analysis
- **Triggers:** `push` + `pull_request` to `main`, with `paths-ignore` for markdown/docs/JSON/YAML so content-only edits don't spin up analysis. Plus a **weekly schedule** (Mon 05:30 UTC) to catch newly-released CodeQL queries.
- **Concurrency:** cancels superseded runs on the same ref.
- **Permissions (least-privilege):** `contents: read`, `security-events: write`, `actions: read`.
- **Matrix** (`fail-fast: false`, parallel):
  | Language | Build mode | What it covers |
  | --- | --- | --- |
  | `javascript-typescript` | `none` | `sap-bw-query` MCP server (`plugins/sap-bw-query/mcp/src/*.mjs` — auth/secrets/connections/untrusted content), `scripts/*.mjs`, tests |
  | `python` | `none` | validator hooks (`plugins/*/hooks/validator.py`), `sap-rpt1` ML scripts |
  | `java` | `none` | Eclipse RCP plugin source (`plugins/sap-bw-query/eclipse/...`) — *see caveat below* |
- Actions pinned to floating `@v4` (current GA major; matches the existing `checkout@v4`/`setup-node@v4` convention; kept current by Dependabot).

### `.github/codeql/codeql-config.yml` — analysis scope
- Excludes generated/vendored content from *analysis*: `node_modules`, `plugins/sap-bw-query/mcp/dist` (the esbuild bundle output), `tests/fixtures`, `**/*.min.js`, `vendor`, `third_party`.

### `.github/dependabot.yml` — dependency + action updates
- Three ecosystems, **weekly**, **grouped** to minimize PR noise (important since `main` requires review on every PR):
  - `github-actions` (root) — keeps `checkout`, `codeql-action`, `setup-node` patched
  - `npm` (root) — devDependencies (validation tooling)
  - `npm` (`/plugins/sap-bw-query/mcp`) — the real runtime dep `@modelcontextprotocol/sdk`, reviewed independently
- Conventional `chore(deps)` commit prefix, labeled.

### `.github/SECURITY.md` — documentation
- New "Automated Security Scanning" section describing CodeQL (languages + schedule) and Dependabot.

## Design notes

- **Java uses `build-mode: none`** because the repo has no Maven/Gradle build. Caveat per [GitHub docs](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages): analysis without a build has reduced accuracy ("Good" vs "Best") and does not analyze generated code. The Java matrix entry is trivial to remove if it proves too noisy.
- **No separate `upload-sarif` step** — `analyze@v4` uploads SARIF automatically; a separate step would be redundant (that action is for external tools only).
- **Floating `@v4` tags** match the rest of the repo's workflows. (The `hook-tests` job in `quality-checks.yml` does SHA-pin, but that's inconsistent with the other jobs there; Dependabot-for-actions gives the patching benefit without the bump-by-hand cost.)

## ⚠️ One-time repo settings (manual — owner only)

These can't be set in a PR; flip them under **Settings → Code security**:
- [ ] **Dependabot** → enable *security updates* (alerting is already on — the push output showed 5 existing alerts on `main`: 1 high, 4 moderate)
- [ ] **Secret scanning** → enable + **push protection** (free for public repos)
- [ ] *(Optional)* Add the CodeQL status check (`Analyze (javascript-typescript)`, etc.) to the `main`-branch Ruleset as a required check

## Verification

- [x] YAML validated locally for all three new files
- [x] Branch based on latest `main`
- [ ] CodeQL runs green on this PR (it triggers on PRs to `main`)
- [ ] Security tab populates results after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated security scanning for JavaScript/TypeScript, Python, and Java code.
  * Added scheduled and change-based checks to identify vulnerabilities and report results.
  * Documented scanning coverage, schedules, results, and vulnerability triage guidance.

* **Maintenance**
  * Added automated weekly dependency update checks for project dependencies and workflow components.
  * Grouped related updates to simplify dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->