### PR TITLE
fix(security): resolve CodeQL parse error and all open alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,10 +8,13 @@ name: "sap-skills CodeQL config"
 # node_modules is already gitignored, but listing it is defense-in-depth for local
 # builds that may leave artifacts behind. dist/ is the esbuild bundle output of
 # the sap-bw-query MCP server (a generated copy of mcp/src/, not source).
+# templates/ holds copy/paste scaffolding snippets with {{placeholder}} tokens
+# (not valid standalone JS) — they are reference material, not application source.
 paths-ignore:
   - node_modules
   - "plugins/sap-bw-query/mcp/dist"
   - "tests/fixtures"
+  - "**/templates"
   - "**/*.min.js"
   - "**/*.min.css"
   - "**/vendor"

--- a/plugins/sap-cap-capire/hooks/validator.mjs
+++ b/plugins/sap-cap-capire/hooks/validator.mjs
@@ -350,7 +350,7 @@ function looksLikeCustomWidgetContent(textLower, filePathLower) {
 }
 
 function hasGlobalStyleInjection(text) {
-  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)/.test(text)
+  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)/.test(text)
     || /document\.head\.insertAdjacentHTML\s*\([^)]*<style/i.test(text);
 }
 

--- a/plugins/sap-cap-capire/hooks/validator.py
+++ b/plugins/sap-cap-capire/hooks/validator.py
@@ -301,7 +301,7 @@ def looks_like_custom_widget_content(text_lower: str, file_path_lower: str) -> b
 
 def has_global_style_injection(text: str) -> bool:
     return bool(
-        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)", text)
+        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)", text)
         or re.search(r"document\.head\.insertAdjacentHTML\s*\([^)]*<style", text, flags=re.IGNORECASE)
     )
 

--- a/plugins/sap-datasphere/hooks/validator.mjs
+++ b/plugins/sap-datasphere/hooks/validator.mjs
@@ -350,7 +350,7 @@ function looksLikeCustomWidgetContent(textLower, filePathLower) {
 }
 
 function hasGlobalStyleInjection(text) {
-  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)/.test(text)
+  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)/.test(text)
     || /document\.head\.insertAdjacentHTML\s*\([^)]*<style/i.test(text);
 }
 

--- a/plugins/sap-datasphere/hooks/validator.py
+++ b/plugins/sap-datasphere/hooks/validator.py
@@ -301,7 +301,7 @@ def looks_like_custom_widget_content(text_lower: str, file_path_lower: str) -> b
 
 def has_global_style_injection(text: str) -> bool:
     return bool(
-        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)", text)
+        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)", text)
         or re.search(r"document\.head\.insertAdjacentHTML\s*\([^)]*<style", text, flags=re.IGNORECASE)
     )
 

--- a/plugins/sap-sac-custom-widget/hooks/validator.mjs
+++ b/plugins/sap-sac-custom-widget/hooks/validator.mjs
@@ -350,7 +350,7 @@ function looksLikeCustomWidgetContent(textLower, filePathLower) {
 }
 
 function hasGlobalStyleInjection(text) {
-  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)/.test(text)
+  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)/.test(text)
     || /document\.head\.insertAdjacentHTML\s*\([^)]*<style/i.test(text);
 }
 

--- a/plugins/sap-sac-custom-widget/hooks/validator.py
+++ b/plugins/sap-sac-custom-widget/hooks/validator.py
@@ -301,7 +301,7 @@ def looks_like_custom_widget_content(text_lower: str, file_path_lower: str) -> b
 
 def has_global_style_injection(text: str) -> bool:
     return bool(
-        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)", text)
+        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)", text)
         or re.search(r"document\.head\.insertAdjacentHTML\s*\([^)]*<style", text, flags=re.IGNORECASE)
     )
 

--- a/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/design-runtime/runtime.js
+++ b/plugins/sap-sac-custom-widget/skills/sap-sac-custom-widget/templates/design-runtime/runtime.js
@@ -320,6 +320,19 @@
     return null;
   }
 
+  // Per the Custom Elements spec: ASCII lowercase letters, digits, and hyphens;
+  // must start with a letter and contain at least one hyphen. Validating the tag
+  // before createElement defends against config-sourced values being reinterpreted
+  // as HTML element names (e.g. "script", "img").
+  var CUSTOM_ELEMENT_TAG_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$/;
+
+  function validateCustomElementTag(tag) {
+    if (!tag || !CUSTOM_ELEMENT_TAG_PATTERN.test(tag)) {
+      throw new Error("Refusing to create element with invalid custom element tag: " + (tag || "(missing)"));
+    }
+    return tag;
+  }
+
   function componentTag(prepared, kind) {
     var component = kind === "styling" ? prepared.stylingComponent : prepared.mainComponent;
     if (component && component.tag) {
@@ -434,7 +447,7 @@
     prepareWidget(widget)
       .then(function(prepared) {
         return loadScripts(scriptUrlsFor(prepared, "main")).then(function() {
-          var tag = componentTag(prepared, "main");
+          var tag = validateCustomElementTag(componentTag(prepared, "main"));
           var tagError = registerTagOwner(tag, widget.id);
           if (tagError) {
             throw new Error(tagError);
@@ -684,7 +697,7 @@
           if (requestId !== app.stylingRequestId || app.selectedWidgetId !== widget.id) {
             return;
           }
-          var tag = componentTag(prepared, "styling");
+          var tag = validateCustomElementTag(componentTag(prepared, "styling"));
           if (!tag || !window.customElements.get(tag)) {
             host.textContent = "No styling panel component registered.";
             return;

--- a/plugins/sap-sac-planning/hooks/validator.mjs
+++ b/plugins/sap-sac-planning/hooks/validator.mjs
@@ -350,7 +350,7 @@ function looksLikeCustomWidgetContent(textLower, filePathLower) {
 }
 
 function hasGlobalStyleInjection(text) {
-  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)/.test(text)
+  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)/.test(text)
     || /document\.head\.insertAdjacentHTML\s*\([^)]*<style/i.test(text);
 }
 

--- a/plugins/sap-sac-planning/hooks/validator.py
+++ b/plugins/sap-sac-planning/hooks/validator.py
@@ -301,7 +301,7 @@ def looks_like_custom_widget_content(text_lower: str, file_path_lower: str) -> b
 
 def has_global_style_injection(text: str) -> bool:
     return bool(
-        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)", text)
+        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)", text)
         or re.search(r"document\.head\.insertAdjacentHTML\s*\([^)]*<style", text, flags=re.IGNORECASE)
     )
 

--- a/plugins/sap-sac-scripting/hooks/validator.mjs
+++ b/plugins/sap-sac-scripting/hooks/validator.mjs
@@ -350,7 +350,7 @@ function looksLikeCustomWidgetContent(textLower, filePathLower) {
 }
 
 function hasGlobalStyleInjection(text) {
-  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)/.test(text)
+  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)/.test(text)
     || /document\.head\.insertAdjacentHTML\s*\([^)]*<style/i.test(text);
 }
 

--- a/plugins/sap-sac-scripting/hooks/validator.py
+++ b/plugins/sap-sac-scripting/hooks/validator.py
@@ -301,7 +301,7 @@ def looks_like_custom_widget_content(text_lower: str, file_path_lower: str) -> b
 
 def has_global_style_injection(text: str) -> bool:
     return bool(
-        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)", text)
+        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)", text)
         or re.search(r"document\.head\.insertAdjacentHTML\s*\([^)]*<style", text, flags=re.IGNORECASE)
     )
 

--- a/plugins/sap-sqlscript/hooks/validator.mjs
+++ b/plugins/sap-sqlscript/hooks/validator.mjs
@@ -350,7 +350,7 @@ function looksLikeCustomWidgetContent(textLower, filePathLower) {
 }
 
 function hasGlobalStyleInjection(text) {
-  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)/.test(text)
+  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)/.test(text)
     || /document\.head\.insertAdjacentHTML\s*\([^)]*<style/i.test(text);
 }
 

--- a/plugins/sap-sqlscript/hooks/validator.py
+++ b/plugins/sap-sqlscript/hooks/validator.py
@@ -301,7 +301,7 @@ def looks_like_custom_widget_content(text_lower: str, file_path_lower: str) -> b
 
 def has_global_style_injection(text: str) -> bool:
     return bool(
-        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)", text)
+        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)", text)
         or re.search(r"document\.head\.insertAdjacentHTML\s*\([^)]*<style", text, flags=re.IGNORECASE)
     )
 

--- a/plugins/sapui5/hooks/validator.mjs
+++ b/plugins/sapui5/hooks/validator.mjs
@@ -350,7 +350,7 @@ function looksLikeCustomWidgetContent(textLower, filePathLower) {
 }
 
 function hasGlobalStyleInjection(text) {
-  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)/.test(text)
+  return /document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)/.test(text)
     || /document\.head\.insertAdjacentHTML\s*\([^)]*<style/i.test(text);
 }
 

--- a/plugins/sapui5/hooks/validator.py
+++ b/plugins/sapui5/hooks/validator.py
@@ -301,7 +301,7 @@ def looks_like_custom_widget_content(text_lower: str, file_path_lower: str) -> b
 
 def has_global_style_injection(text: str) -> bool:
     return bool(
-        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[A-Za-z_$\w]*)\s*\)", text)
+        re.search(r"document\.head\.appendChild\s*\(\s*(?:style|[A-Za-z_$][\w$]*(?:Style|Css|CSS)[\w$]*)\s*\)", text)
         or re.search(r"document\.head\.insertAdjacentHTML\s*\([^)]*<style", text, flags=re.IGNORECASE)
     )
 


### PR DESCRIPTION
## Summary

Resolves **1 parse error** and **30 open code-scanning alerts** (2 high, 28 medium) from 3 root causes. No infrastructure was broken — all CodeQL runs and analyses were already succeeding; this clears the findings.

| Root cause | Severity | Count |
|-----------|----------|-------|
| Parse error: `{{Field1}}` bare object keys in template JS | parse error | 1 |
| Overly permissive regex range `[A-Za-z_$\w]` | medium | 28 |
| DOM XSS via `document.createElement(tag)` | **high** | 2 |

## Changes

### Fix 1 — Parse error (JS/TS extractor)
`controller.js` uses mustache `{{placeholder}}` tokens as **bare object property keys** (invalid JS — reproduces with `node --check`). Added `**/templates` to `paths-ignore` in `.github/codeql/codeql-config.yml`. Template snippets are copy/paste scaffolding with intentional placeholders, not application source.

### Fix 2 — `js/overly-large-range` + `py/overly-large-range` (28 medium)
The `hasGlobalStyleInjection` regex had a trailing char class `[A-Za-z_$\w]` where the `A-Z`/`a-z` ranges overlap with `\w`. Collapsed to `[\w$]` (behavior-equivalent since `\w` = `[A-Za-z0-9_]`). Applied across 7 `validator.py` + 7 `validator.mjs` files (kept byte-identical per `test-hooks.mjs`).

Verified equivalent across 12 test cases. The leading `[A-Za-z_$]` class (identifier-start semantics) was left unchanged — it was **not** flagged.

### Fix 3 — `js/xss-through-dom` (2 high)
`runtime.js` flows config from `JSON.parse(el.textContent)` → `componentTag()` → `document.createElement(tag)` with no validation. Added `validateCustomElementTag()` enforcing the Custom Elements name spec (lowercase ASCII letters/digits/hyphens, must contain a hyphen), applied at both `createElement` sinks. Legitimate SAC widget tags pass; injection tags (`script`, `img`, etc.) are rejected.

## Verification
- ✅ `node --check` on `runtime.js` — syntax OK
- ✅ `bun run test:hooks` — hook identity + behavior tests pass
- ✅ `bun run test:hook-contracts` — contracts pass (8 plugins)
- ✅ `validate-templates.mjs` — passes
- ✅ Byte-identity preserved across 14 validator files
- ✅ Regex equivalence proven (12/12 cases match)

## Files changed (16)
- `.github/codeql/codeql-config.yml`
- `plugins/<7 plugins>/hooks/validator.py`
- `plugins/<7 plugins>/hooks/validator.mjs`
- `plugins/sap-sac-custom-widget/.../design-runtime/runtime.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for custom-element names used by custom widgets, with clear error handling for invalid tags.

* **Bug Fixes**
  * Improved detection of global style injection patterns across supported plugins, including identifiers containing underscores, digits, and dollar signs.
  * Preserved detection for common style and CSS variable naming conventions.

* **Chores**
  * Excluded template scaffolding from automated CodeQL analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->