### PR TITLE
docs: add plain-language communication rule to CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Read `CLAUDE.md` for the full repository context before making project changes.
 
+## Most Important Rule: Plain Language
+
+- Talk to the user in clear, easy, short end-user language.
+- Do not use jargon. If a technical term cannot be avoided, explain it in one short sentence.
+- This rule is the most important one in this file and in `CLAUDE.md`.
+
 ## Oracle Shared Reviews
 
 - Use Oracle for a second opinion when stuck, when reviewing architecture, before risky refactors, or when validating a plan with another model.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,14 @@ Install: `brew tap JordanCoin/tap && brew install codemap`
 
 ## Critical Directives
 
-### 1. ALWAYS Use plugin-dev First
+### 1. ALWAYS Use Plain Language With the User (Most Important Rule)
+
+Every message to the user — answers, summaries, status updates, plans, and
+error explanations — must use clear, easy, short end-user language. Do not
+use jargon. If a technical term cannot be avoided, explain it in one short
+sentence. This rule is more important than any other directive in this file.
+
+### 2. ALWAYS Use plugin-dev First
 
 For all general plugin development tasks:
 - Creating skills, commands, agents, hooks
@@ -68,7 +75,7 @@ For all general plugin development tasks:
 - MCP server integration
 - Basic validation
 
-### 2. ALWAYS Use Manual Review Process
+### 3. ALWAYS Use Manual Review Process
 
 **FORBIDDEN - Automated Refactoring**:
 - Creating Python/shell scripts to refactor skills
@@ -86,7 +93,7 @@ For all general plugin development tasks:
 **Why**: Skills require context-aware decisions. Automation introduces subtle
 errors that break functionality.
 
-### 3. Oracle Shared Reviews
+### 4. Oracle Shared Reviews
 
 Use Oracle as a browser-first second-opinion tool when stuck, for architecture
 review, before risky refactors, or for second-model validation of important


### PR DESCRIPTION
## What changed

- Added a new rule to `CLAUDE.md` (as Critical Directive 1) and `AGENTS.md` (as the first section): all communication with the user must use clear, easy, short end-user language, with no jargon. If a technical term cannot be avoided, it must be explained in one short sentence.
- Renumbered the existing Critical Directives in `CLAUDE.md` (old 1/2/3 are now 2/3/4).

Docs-only change; no code or workflows touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring clear, concise, jargon-free language in assistant communications.
  * Updated directive numbering to reflect the new top-priority plain-language rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->