### PR TITLE
fix(ci): GitHub Actions security hardening from 2025–2026 threat research

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -61,7 +61,14 @@ This repository is covered by two free GitHub features for public repos (no paid
 - Config: [`.github/dependabot.yml`](dependabot.yml)
 - Surfaces vulnerability advisories and opens PRs for outdated dependencies (npm) and pinned GitHub Actions, grouped weekly to reduce review load.
 
-Findings from either tool are triaged like any other reported vulnerability (see *Reporting a Vulnerability* above).
+### Workflow Lint Gate (actionlint + zizmor)
+- Script: `npm run lint:workflows`, run inside [`quality-checks.yml`](workflows/quality-checks.yml) on every push/PR to `main`. The binaries are downloaded from their official releases at pinned versions (actionlint v1.7.12, zizmor v1.29.0) and verified against embedded SHA-256 digests before use.
+- **actionlint** checks workflow syntax, correctness, and embedded shell scripts. **zizmor** checks Actions security rules: unpinned action references, over-broad token scopes, template injection, and cache poisoning.
+- **Pinning policy:** every `uses:` reference is pinned to a full commit SHA (`owner/action@<40-char-sha> # vX.Y.Z`), Dependabot keeps the SHAs current, and all checkouts run with `persist-credentials: false`.
+- **Hardening policy:** every workflow declares least-privilege `permissions:`, a `timeout-minutes` on every job, and a concurrency group; no `${{ }}` template expressions appear inside `run:` shell bodies (values arrive through step `env:`).
+- Any finding fails the build. Suppression annotations are not used. Background and incident research: [`docs/project/github-actions-security-hardening-2026-08-29.md`](../docs/project/github-actions-security-hardening-2026-08-29.md).
+
+Findings from any of these tools are triaged like any other reported vulnerability (see *Reporting a Vulnerability* above).
 
 ## Known Security Considerations
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,10 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,22 +60,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       # analyze@v4 builds the database, runs the queries, and uploads SARIF to
       # the Security tab — no separate upload-sarif step is needed (that action
       # is only for results produced by external tools).
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-security-checks.yml
+++ b/.github/workflows/dependency-security-checks.yml
@@ -12,10 +12,14 @@ concurrency:
   group: dependency-security-checks-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   enforce-dependency-hardening:
     name: Enforce dependency hardening policy
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 

--- a/.github/workflows/dependency-security-checks.yml
+++ b/.github/workflows/dependency-security-checks.yml
@@ -31,15 +31,21 @@ jobs:
           persist-credentials: false
 
       - name: Detect dependency context and enforce policy
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
+            HEAD_SHA="$PR_HEAD_SHA"
           else
-            BASE_SHA="${{ github.event.before }}"
-            HEAD_SHA="${{ github.sha }}"
+            BASE_SHA="$PUSH_BEFORE"
+            HEAD_SHA="$CURRENT_SHA"
             if [ "$BASE_SHA" = "" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
               BASE_SHA="$(git rev-parse "${HEAD_SHA}~1")"
             fi

--- a/.github/workflows/dependency-security-checks.yml
+++ b/.github/workflows/dependency-security-checks.yml
@@ -21,9 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect dependency context and enforce policy
         run: |

--- a/.github/workflows/local-fixture-smoke.yml
+++ b/.github/workflows/local-fixture-smoke.yml
@@ -30,10 +30,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/mcp-freshness.yml
+++ b/.github/workflows/mcp-freshness.yml
@@ -30,10 +30,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -117,6 +117,22 @@ jobs:
       - name: Validate command and agent frontmatter
         run: ./scripts/validate-command-agent-frontmatter.mjs
 
+      - name: Install workflow security linters
+        run: |
+          cd "$RUNNER_TEMP"
+          curl -fsSL -o actionlint_1.7.12_linux_amd64.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          curl -fsSL -o zizmor-x86_64-unknown-linux-gnu.tar.gz https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-x86_64-unknown-linux-gnu.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum -c -
+          echo "dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839  zizmor-x86_64-unknown-linux-gnu.tar.gz" | sha256sum -c -
+          tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
+          tar -xzf zizmor-x86_64-unknown-linux-gnu.tar.gz zizmor
+          mkdir -p "$RUNNER_TEMP/bin"
+          mv actionlint zizmor "$RUNNER_TEMP/bin/"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Lint GitHub Actions workflows
+        run: npm run lint:workflows
+
       - name: Run full validation pipeline
         run: npm run validate
 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install system dependencies
         run: sudo apt-get update -qq && sudo apt-get install -y -qq libxml2-utils

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -9,13 +9,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: quality-checks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-skills:
     name: validate-skills
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -139,6 +144,7 @@ jobs:
   hook-tests:
     name: hook-tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: read
     strategy:
@@ -147,12 +153,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/sap-bw-query-bundle.yml
+++ b/.github/workflows/sap-bw-query-bundle.yml
@@ -16,8 +16,10 @@ jobs:
   build:
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.18.0
           cache: npm
@@ -99,7 +101,7 @@ jobs:
           if (($output -join "`n") -match '"smoke"\s*:\s*"FAIL"') { throw "Standalone round-trip smoke reported FAIL" }
           Write-Host "Standalone round-trip smoke passed."
       - name: Upload signed release artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bw-automation-studio-${{ steps.bundle.outputs.version }}-windows-x64.zip
           path: |

--- a/.github/workflows/sap-bw-query-bundle.yml
+++ b/.github/workflows/sap-bw-query-bundle.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.18.0
-          cache: npm
-          cache-dependency-path: plugins/sap-bw-query/mcp/package-lock.json
+          # Cache disabled: release signing job; a poisoned npm cache is not worth the speed gain.
+          package-manager-cache: false
       - name: Install and test MCP
         shell: pwsh
         run: |

--- a/.github/workflows/sap-bw-query-bundle.yml
+++ b/.github/workflows/sap-bw-query-bundle.yml
@@ -48,11 +48,13 @@ jobs:
           [System.IO.File]::WriteAllText((Join-Path $env:RUNNER_TEMP "bw-studio-signing.pem"), $env:BW_STUDIO_SIGNING_PRIVATE_KEY)
       - name: Build and sign portable bundle
         shell: pwsh
+        env:
+          SIGNING_KEY_ID: ${{ vars.BW_STUDIO_SIGNING_KEY_ID }}
         run: |
           & plugins/sap-bw-query/bundle/Build-BwStudio.ps1 `
             -OutputDirectory (Join-Path $env:RUNNER_TEMP "bw-release") `
             -SigningPrivateKeyPath (Join-Path $env:RUNNER_TEMP "bw-studio-signing.pem") `
-            -SigningKeyId "${{ vars.BW_STUDIO_SIGNING_KEY_ID }}"
+            -SigningKeyId "$env:SIGNING_KEY_ID"
       - name: Deploy bundle and run standalone round-trip smoke
         shell: pwsh
         env:

--- a/.github/workflows/sap-bw-query-bundle.yml
+++ b/.github/workflows/sap-bw-query-bundle.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   build:
     runs-on: windows-2025
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/validate-frontmatter.yml
+++ b/.github/workflows/validate-frontmatter.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Validate changed SKILL.md files
         if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^plugins/[^/]*/skills/[^/]*/SKILL\.md$' || true)
+          CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD" | grep '^plugins/[^/]*/skills/[^/]*/SKILL\.md$' || true)
           if [ -z "$CHANGED" ]; then
             echo "No plugin SKILL.md files changed, skipping validation"
             exit 0
@@ -59,7 +61,9 @@ jobs:
       - name: Summary
         if: always()
         run: |
-          echo "### Frontmatter Validation" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Validated installable plugin \`SKILL.md\` files in \`plugins/*/skills/*/\`" >> $GITHUB_STEP_SUMMARY
-          echo "Run \`./scripts/validate-frontmatter.sh\` locally to check before pushing." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Frontmatter Validation"
+            echo ""
+            echo "Validated installable plugin \`SKILL.md\` files in \`plugins/*/skills/*/\`"
+            echo "Run \`./scripts/validate-frontmatter.sh\` locally to check before pushing."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-frontmatter.yml
+++ b/.github/workflows/validate-frontmatter.yml
@@ -20,9 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Make script executable
         run: chmod +x scripts/validate-frontmatter.sh

--- a/.github/workflows/validate-frontmatter.yml
+++ b/.github/workflows/validate-frontmatter.yml
@@ -17,6 +17,7 @@ jobs:
   validate-frontmatter:
     name: Validate SKILL.md Frontmatter
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/validate-json-schemas.yml
+++ b/.github/workflows/validate-json-schemas.yml
@@ -17,6 +17,7 @@ jobs:
   validate-json-schemas:
     name: Validate JSON Schemas
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/validate-json-schemas.yml
+++ b/.github/workflows/validate-json-schemas.yml
@@ -20,10 +20,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install pinned devDependencies
         run: bun install --frozen-lockfile
@@ -45,7 +47,7 @@ jobs:
 
       - name: Upload validation results on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: validation-errors
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to SAP Skills will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Hardened all 8 GitHub Actions workflows against supply-chain attacks: pinned all 20 action references to verified commit SHAs with `persist-credentials: false` on all 9 checkout steps, declared least-privilege `permissions:` plus per-job `timeout-minutes` and concurrency groups in every workflow, removed all `${{ }}` template expressions from `run:` shell bodies (values now arrive through step `env:` mappings), and disabled npm package-manager caching in the release-signing workflow (`package-manager-cache: false`) to close the cache-poisoning exposure.
+- Added a workflow lint gate to `quality-checks.yml` (`npm run lint:workflows`: actionlint v1.7.12 + zizmor v1.29.0, installed in CI from pinned releases verified against embedded SHA-256 digests) that fails on any finding; the gate is green with zero suppression annotations. Background, incident research, and watch items: `docs/project/github-actions-security-hardening-2026-08-29.md`.
+
 ## [2.4.1] - 2026-08-07
 
 ### Changed

--- a/docs/project/audit-index.md
+++ b/docs/project/audit-index.md
@@ -11,6 +11,7 @@ agent, hook, template, and reference resources only.
 - `plugin-skills-third-pass-audit-2026-06-14.md` - effectiveness audit, capability indexes, output contracts, and oversized-reference routing.
 - `source-verification-ledger.json` - current fourth-pass freshness ledger that guards `metadata.last_verified`.
 - `package-evidence/2026-06-15.json` - public registry evidence for MCP/package freshness candidates.
+- `github-actions-security-hardening-2026-08-29.md` - workflow supply-chain hardening: SHA pinning, least-privilege tokens, timeouts, expression hygiene, and the actionlint + zizmor CI gate.
 
 ## Policy
 

--- a/docs/project/github-actions-security-hardening-2026-08-29.md
+++ b/docs/project/github-actions-security-hardening-2026-08-29.md
@@ -2,7 +2,7 @@
 
 **Scope:** all 8 workflow files under `.github/workflows/`
 **Branch:** `chore/gh-actions-security-hardening` (off `main`)
-**Commits:** `3af29a7`, `f4958a5`, `7a70e07`, `f97880f`, plus the final cache fix
+**Commits:** `3af29a7`, `f4958a5`, `7a70e07`, `f97880f`, plus the final cache fix (`78e4ca2`)
 **Result:** `npm run lint:workflows` exits 0 with zero findings and zero suppression annotations.
 
 ---
@@ -19,7 +19,7 @@
 
 ## Why: what happened to other projects in 2025–2026
 
-Attackers stopped attacking only application code. They now attack the CI setup itself. These incidents shaped the fixes in this repository.
+Attackers no longer attack only application code; they now also attack the CI setup itself. These incidents shaped the fixes in this repository.
 
 ### tj-actions/changed-files (March 2025) — CVE-2025-30066
 
@@ -92,7 +92,7 @@ Every push and pull request to `main` now runs a workflow lint gate as part of `
 - **actionlint** v1.7.12 checks workflow syntax, correctness, and embedded shell scripts (with shellcheck). https://github.com/rhysd/actionlint
 - **zizmor** v1.29.0 checks GitHub Actions security rules, for example unpinned actions, over-broad token scopes, template injection, and cache poisoning. https://zizmor.sh/
 
-**How the binaries are verified.** The install step downloads both release archives over HTTPS from their official GitHub releases. It checks each archive against a SHA-256 digest literal written inside the workflow step with `sha256sum -c -`. A mismatch fails the job. The actionlint digest is also matched against the official checksum file published with that release. zizmor publishes no checksum file, so its digest was computed once from the official release asset and recorded here. The step adds no new third-party actions; the repository deliberately does not use `zizmor-action` for this reason.
+**How the binaries are verified.** The install step downloads both release archives over HTTPS from their official GitHub releases. It checks each archive against a SHA-256 digest literal written inside the workflow step with `sha256sum -c -`. A mismatch fails the job. The actionlint digest was cross-checked against the official checksum file published with that release when the digest was added; CI itself checks only the embedded digest literal. zizmor publishes no checksum file, so its digest was computed once from the official release asset and recorded here. The step adds no new third-party actions; the repository deliberately does not use `zizmor-action` for this reason.
 
 **How to run locally.** Install both tools (for example with Homebrew) and run:
 

--- a/docs/project/github-actions-security-hardening-2026-08-29.md
+++ b/docs/project/github-actions-security-hardening-2026-08-29.md
@@ -100,7 +100,7 @@ Every push and pull request to `main` now runs a workflow lint gate as part of `
 npm run lint:workflows
 ```
 
-This runs `actionlint && zizmor .github/workflows/`. Any finding fails the command, and the CI job fails with it.
+This runs actionlint and zizmor over `.github/workflows/` and fails if either tool reports a finding. Both tools always run, so one pass shows every finding. The CI job runs the same script, so a finding fails the job too.
 
 **Current result.** The gate is green: actionlint reports no findings, and zizmor reports no findings. Zero suppression annotations (`#! ignore`) exist in the repository. Dependabot keeps the pinned SHAs current with grouped weekly pull requests (`.github/dependabot.yml`), so pinning does not freeze the actions in time.
 

--- a/docs/project/github-actions-security-hardening-2026-08-29.md
+++ b/docs/project/github-actions-security-hardening-2026-08-29.md
@@ -1,0 +1,133 @@
+# GitHub Actions Security Hardening (2026-08-29)
+
+**Scope:** all 8 workflow files under `.github/workflows/`
+**Branch:** `chore/gh-actions-security-hardening` (off `main`)
+**Commits:** `3af29a7`, `f4958a5`, `7a70e07`, `f97880f`, plus the final cache fix
+**Result:** `npm run lint:workflows` exits 0 with zero findings and zero suppression annotations.
+
+---
+
+## Background: the words this document uses
+
+- A **workflow** is a file under `.github/workflows/` that describes automated steps. GitHub runs these steps on its own computers when events happen, for example a push or a new release.
+- **GITHUB_TOKEN** is an automatic login pass that GitHub gives to each workflow run. It can read the repository and, if allowed, change things in it. A workflow should get only the small set of rights it needs. This is the least-privilege rule.
+- An **action** is a reusable step that a workflow can call, for example `actions/checkout`. A workflow names an action plus a version, for example `actions/checkout@v4`. That version part is a **tag**.
+- A **mutable tag** is a name like `v4` that a repository owner can move to point at different code at any time. If an attacker moves it, every workflow that names `v4` runs the attacker's code.
+- **SHA pinning** replaces the tag with the exact commit fingerprint (a 40-character SHA, for example `3d3c42e5...`) of one immutable piece of code. A commit cannot change. With SHA pinning, a moved tag does not affect the workflow. A comment like `# v4.0.1` records which release the SHA stands for.
+- **`persist-credentials: false`** is a checkout setting. It stops the checkout action from leaving the GITHUB_TOKEN inside the job's `.git` folder. Without it, any later step can read the token from disk.
+- **Cache poisoning** is an attack on GitHub's build caches. An attacker writes hostile files into a cache. A later workflow, often a release workflow, restores the cache and runs the hostile files.
+
+## Why: what happened to other projects in 2025–2026
+
+Attackers stopped attacking only application code. They now attack the CI setup itself. These incidents shaped the fixes in this repository.
+
+### tj-actions/changed-files (March 2025) — CVE-2025-30066
+
+An attacker stole a maintainer's personal access token, rewrote the `v1` tag of a helper action, and then rewrote every `tj-actions/changed-files` tag from `v1` to `v45.0.7` to point at code that dumped runner memory, including CI secrets, into build logs. About 23,000 repositories were affected (Wiz estimate). The lesson: a mutable tag can be hijacked after the fact. Pin actions to commit SHAs.
+
+- https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066-and-reviewdogaction
+- https://github.com/tj-actions/changed-files/security/advisories/GHSA-mw4p-6x4p-x5m5
+- https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066
+
+### GhostAction (September 2025)
+
+Attackers with write access pushed look-alike malicious workflow files to 817 repositories. The workflows stole 3,325 secrets for npm, PyPI, Docker Hub, and cloud services. The lesson: a workflow file is a secret-stealing program. A repository should review workflow changes with the same care as code changes, and a linter gate makes odd workflow content visible in review.
+
+- https://blog.gitguardian.com/ghostaction-campaign-3-325-secrets-stolen/
+- https://www.stepsecurity.io/blog/ghostaction-campaign-over-3-000-secrets-stolen-through-malicious-github-workflows
+
+### Trivy ecosystem compromise (March 2026) — CVE-2026-33634
+
+Stolen credentials published one malicious Trivy release and force-pushed 76 of the project's 77 version tags. The scanning action became an information stealer. The lesson repeats the tj-actions lesson with a different victim: force-pushed tags are a live delivery channel. SHA pinning blocks it.
+
+- https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23
+- https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/
+
+### prt-scan campaign (March–April 2026)
+
+One attacker ran six attack waves against more than 500 repositories. Every attack abused the `pull_request_target` trigger, which runs a workflow from a pull request with write access. AI tooling automated the exploitation. The lesson: avoid `pull_request_target`. This repository never used it; an audit confirmed this.
+
+- https://www.wiz.io/blog/six-accounts-one-actor-inside-the-prt-scan-supply-chain-campaign
+
+### Megalodon (May 2026)
+
+Attackers used trusted bot accounts to forge more than 5,700 commits and backdoored 5,561 repositories in about 6 hours. The forged commits replaced workflow files with base64-obfuscated secret stealers. The lesson: automated changes to workflow files deserve their own review, and a static gate on workflow content catches low-effort obfuscation.
+
+- https://www.stepsecurity.io/blog/megalodon-mass-github-actions-secret-exfiltration-across-5-500-public-repositories
+
+A related npm worm, Shai-Hulud (September 2025), stole npm publish tokens and created malicious workflow files in victim repositories to spread further. npm publishing credentials are CI credentials (https://www.wiz.io/blog/shai-hulud-npm-supply-chain-attack).
+
+**Attribution caution:** vendors disagree on some 2026 details, for example Shai-Hulud package counts. Third parties inferred a link between Megalodon and GitHub's own 2026 breach; GitHub has not confirmed it. The lessons above do not depend on those disputed details.
+
+## What we found and fixed
+
+zizmor and actionlint audited the eight workflows. This table shows the main findings and the state now.
+
+| Finding | Before | After |
+|---|---|---|
+| Mutable (tag-pinned) action refs | 17 of 20 `uses:` refs | 0; all 20 refs pinned to commit SHAs |
+| Checkout steps leaking the token to disk (`persist-credentials`) | 2 of 9 checkouts opted out | 9 of 9 set `persist-credentials: false` |
+| GITHUB_TOKEN permissions | Some workflows had no explicit `permissions:` | All 8 workflows declare least-privilege `permissions:` |
+| Missing job timeouts | 5 of 9 jobs had none | All 9 jobs set `timeout-minutes` |
+| Missing concurrency groups | 1 of 8 workflows had none | All 8 workflows set a concurrency group |
+| Expressions (`${{ }}`) inside `run:` shell | 7 sites in 3 files | 0; all values now arrive through step `env:` |
+| npm cache in the release workflow | Caching enabled | Disabled with `package-manager-cache: false` |
+
+The only elevated token scope left anywhere is `security-events: write` in `codeql.yml`. CodeQL needs it to upload scan results. A comment in the file states this.
+
+## The changes, task by task
+
+1. **CI gate (commit `3af29a7`).** Added the `lint:workflows` script to `package.json` and two steps to `quality-checks.yml`: one installs the linters with checksum verification, one runs the gate. The gate failed at first by design (red baseline) to record the findings.
+2. **SHA pinning and credential persistence (commit `f4958a5`).** Replaced all 17 tag-pinned refs with verified commit SHAs plus `# vX.Y.Z` comments. Each SHA was resolved with `git ls-remote` and cross-checked through the GitHub API, including the peeled commit for the annotated `github/codeql-action` tag. Added `persist-credentials: false` to the 7 checkouts that missed it.
+3. **Token scopes, timeouts, concurrency (commit `7a70e07`).** Added a top-level `permissions: contents: read` where missing, an explicit permissions block on the CodeQL job, `timeout-minutes` to the 5 jobs that lacked one, and a concurrency group to `quality-checks.yml`.
+4. **Expression hygiene (commit `f97880f`).** Moved 7 `${{ }}` interpolations out of `run:` shells in 3 files into step `env:` entries and quoted the shell uses. Also fixed 5 shellcheck style findings in `validate-frontmatter.yml`. The expressions can no longer write shell syntax into a command.
+5. **Cache opt-out (this branch's final fix).** `actions/setup-node` v7 turns on package-manager caching by default. The release workflow now sets `package-manager-cache: false` to turn it off. See the next section.
+
+## The CI gate
+
+Every push and pull request to `main` now runs a workflow lint gate as part of `quality-checks.yml`.
+
+**Tools**
+
+- **actionlint** v1.7.12 checks workflow syntax, correctness, and embedded shell scripts (with shellcheck). https://github.com/rhysd/actionlint
+- **zizmor** v1.29.0 checks GitHub Actions security rules, for example unpinned actions, over-broad token scopes, template injection, and cache poisoning. https://zizmor.sh/
+
+**How the binaries are verified.** The install step downloads both release archives over HTTPS from their official GitHub releases. It checks each archive against a SHA-256 digest literal written inside the workflow step with `sha256sum -c -`. A mismatch fails the job. The actionlint digest is also matched against the official checksum file published with that release. zizmor publishes no checksum file, so its digest was computed once from the official release asset and recorded here. The step adds no new third-party actions; the repository deliberately does not use `zizmor-action` for this reason.
+
+**How to run locally.** Install both tools (for example with Homebrew) and run:
+
+```sh
+npm run lint:workflows
+```
+
+This runs `actionlint && zizmor .github/workflows/`. Any finding fails the command, and the CI job fails with it.
+
+**Current result.** The gate is green: actionlint reports no findings, and zizmor reports no findings. Zero suppression annotations (`#! ignore`) exist in the repository. Dependabot keeps the pinned SHAs current with grouped weekly pull requests (`.github/dependabot.yml`), so pinning does not freeze the actions in time.
+
+## The cache decision in the release workflow
+
+`sap-bw-query-bundle.yml` builds and signs the BW Automation Studio release bundle, and it runs on `release: published` events. Release workflows are prime targets for cache poisoning: an attacker who poisons a cache reaches the signing environment, and the poisoned output reaches users.
+
+zizmor flagged this workflow because `actions/setup-node` v7 enables package-manager caching by default. Removing the old `cache: npm` input was not enough, because the default turns caching back on. The workflow now sets `package-manager-cache: false` explicitly. A cold `npm ci` costs some seconds on one release job; a poisoned cache could steal the signing key. The trade-off is clear, so the cache stays off. The same reasoning applies to every future release or signing workflow in this repository.
+
+## Platform changes and watch items
+
+### Secure-by-default changes (December 8, 2025)
+
+GitHub changed platform behavior for everyone. `pull_request_target` runs now anchor to the workflow file on the default branch, so an edited workflow in a pull request no longer runs with write access. Branch protection environment rules no longer match pull request events. `actions/checkout` v6 and later store the persisted token in the runner's temp directory instead of the `.git` folder. This repository's fixes stay necessary: explicit `permissions:` remains each repository's job, because the platform did not change default token scopes (https://github.com/orgs/community/discussions/179107, https://docs.github.com/actions/reference/authentication-in-a-workflow).
+
+### Watch items (2026 roadmap)
+
+GitHub announced further platform work (https://github.blog/news-insights/product-news/whats-coming-to-our-github-actions-2026-security-roadmap/):
+
+- **Scoped secrets:** secrets that a job can read only in narrow, declared scopes. Adopt when available.
+- **Egress firewall:** a layer-7 network allowlist for GitHub-hosted runners. Adopt for the release workflow when available.
+- **Workflow dependency lockfile:** transitively SHA-pins nested action references. Adopt when available.
+
+Also on the watch list: an organization-level policy that requires SHA pinning (announced August 2025, https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/), and runtime monitoring with egress control (the StepSecurity Harden-Runner class of tooling, which detected the tj-actions theft live).
+
+## Verification record
+
+- Before: `npm run lint:workflows` exited 1 with 19 high, 7 low, and 1 informational zizmor findings plus 5 actionlint (shellcheck) findings.
+- After: the command exits 0. actionlint reports no findings. zizmor reports "No findings to report" (5 findings are suppressed by zizmor's own default persona rules, not by this repository).
+- The full validation pipeline (`npm run validate`) passes on the final state.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test:hook-contracts": "node ./scripts/test-hook-contracts.mjs",
     "test:codex": "node ./tests/codex-layer.test.mjs",
     "validate:manifest-drift": "./scripts/validate-manifest-drift.mjs",
-    "smoke:local-fixtures": "./scripts/smoke-local-fixtures.mjs"
+    "smoke:local-fixtures": "./scripts/smoke-local-fixtures.mjs",
+    "lint:workflows": "actionlint && zizmor .github/workflows/"
   },
   "devDependencies": {
     "@steipete/oracle": "0.16.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:codex": "node ./tests/codex-layer.test.mjs",
     "validate:manifest-drift": "./scripts/validate-manifest-drift.mjs",
     "smoke:local-fixtures": "./scripts/smoke-local-fixtures.mjs",
-    "lint:workflows": "actionlint && zizmor .github/workflows/"
+    "lint:workflows": "actionlint .github/workflows/*.y*ml; a=$?; zizmor .github/workflows/; z=$?; [ \"$a\" -eq 0 ] && [ \"$z\" -eq 0 ]"
   },
   "devDependencies": {
     "@steipete/oracle": "0.16.1",


### PR DESCRIPTION
## Summary

Research-driven hardening of all 8 GitHub Actions workflows, based on the 2025–2026 wave of Actions supply-chain attacks (tj-actions/changed-files CVE-2025-30066, Trivy CVE-2026-33634, GhostAction, Megalodon, prt-scan) and GitHub's Aug 2025 SHA-pinning policy + Dec 2025 secure-by-default changes. Full research digest with sources: `docs/project/github-actions-security-hardening-2026-08-29.md` (in this PR).

## Changes

| Area | Before | After |
|---|---|---|
| Pinned action refs | 3/20 SHA-pinned | **20/20** full-commit SHA + `# vX.Y.Z` comment (Dependabot keeps them fresh) |
| `persist-credentials: false` | 2/9 checkouts | **9/9** |
| Top-level `permissions:` | 7/8 workflows | **8/8** (+ explicit job-level on codeql `analyze`) |
| Job `timeout-minutes` | 3 workflows | **9/9 jobs** |
| Concurrency groups | 7/8 | **8/8** |
| `${{ }}` inside `run:` bodies | 3 sites | **0** (env indirection) |
| Workflow static analysis | none | **actionlint v1.7.12 + zizmor v1.29.0 gate in CI**, checksum-verified pinned binaries, no new third-party Actions |

Also: npm cache explicitly disabled in the release-signing workflow (`package-manager-cache: false` — setup-node v7 caches by default, so removing `cache: npm` alone was not enough), 5 pre-existing shellcheck findings fixed, new hardening doc + SECURITY.md/audit-index/CHANGELOG updates.

## Verification

- `npm run lint:workflows` → exit 0 (actionlint + zizmor: no findings, zero suppression annotations)
- `npm run validate` → full pipeline green (incl. hook + contract tests)
- Every pinned SHA resolved and verified via `git ls-remote` + GitHub API; both embedded tool digests independently re-verified against official release assets
- Executed via subagent-driven development: per-task spec+quality reviews on all 5 tasks, plus a whole-branch review (verdict: ready to merge, zero Critical/Important findings)

## Notes for review

- No triggers changed; no scheduled jobs added; the gate runs inside the existing `quality-checks.yml` push/PR triggers.
- Watch the first CI run: the new install step downloads both linter binaries and verifies embedded SHA-256 digests before extraction.
- Unreleased CHANGELOG section used deliberately (no version bump invented for a CI-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened CI workflows with pinned action versions, restricted permissions, credential protection, timeouts, and concurrency controls.
  * Added automated workflow security linting that blocks builds when issues are detected.
  * Disabled package-manager caching in the release process to reduce supply-chain risk.

* **Documentation**
  * Added security-hardening guidance, audit records, and unreleased changelog notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->