### PR TITLE
fix: regenerate bun.lock after oracle 0.17.1 bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "sap-skills-validation",
       "devDependencies": {
-        "@steipete/oracle": "0.16.1",
+        "@steipete/oracle": "0.17.1",
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^3.0.1",
       },
@@ -52,7 +52,7 @@
 
     "@inquirer/type": ["@inquirer/type@4.0.7", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -98,7 +98,7 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@steipete/oracle": ["@steipete/oracle@0.16.1", "", { "dependencies": { "@anthropic-ai/tokenizer": "^0.0.4", "@google/genai": "^2.13.0", "@google/generative-ai": "^0.24.1", "@modelcontextprotocol/sdk": "^1.29.0", "@steipete/sweet-cookie": "^0.4.0", "chalk": "^5.6.2", "chrome-launcher": "^1.2.1", "chrome-remote-interface": "^0.34.0", "clipboardy": "^5.3.2", "commander": "^15.0.0", "dotenv": "^17.4.2", "fast-glob": "^3.3.3", "gpt-tokenizer": "^3.4.0", "inquirer": "14.0.2", "json5": "^2.2.3", "kleur": "^4.1.5", "markdansi": "0.3.2", "openai": "^6.48.0", "osc-progress": "^0.3.2", "qs": "^6.15.3", "shiki": "^4.3.1", "toasted-notifier": "^10.1.0", "tokentally": "^0.1.2", "zod": "^4.4.3" }, "bin": { "oracle": "dist/bin/oracle-cli.js", "oracle-mcp": "dist/bin/oracle-mcp.js" } }, "sha512-oJEAcWLvLihtSOGqznN4ErGIE7GEpVWpx02a5JUwoqeQql/lgWyc7ASnEegov3MGpGROF13CkgcISPgtw2INqg=="],
+    "@steipete/oracle": ["@steipete/oracle@0.17.1", "", { "dependencies": { "@anthropic-ai/tokenizer": "^0.0.4", "@google/genai": "^2.15.0", "@google/generative-ai": "^0.24.1", "@modelcontextprotocol/sdk": "^1.30.0", "@steipete/sweet-cookie": "^0.4.1", "chalk": "^6.0.0", "chrome-launcher": "^1.2.1", "chrome-remote-interface": "^0.34.0", "clipboardy": "^5.3.2", "commander": "^15.0.0", "dotenv": "^17.4.2", "fast-glob": "^3.3.3", "gpt-tokenizer": "^3.4.0", "inquirer": "14.0.2", "json5": "^2.2.3", "kleur": "^4.1.5", "markdansi": "0.3.3", "openai": "^7.4.0", "osc-progress": "^0.3.2", "qs": "^6.15.3", "shiki": "^4.4.2", "toasted-notifier": "^10.1.0", "tokentally": "^0.1.3", "zod": "^4.4.3" }, "bin": { "oracle": "dist/bin/oracle-cli.js", "oracle-mcp": "dist/bin/oracle-mcp.js" } }, "sha512-bq4SqMvRtT5Im+R57UPSXTV5p/BFTU24OXgGXqx2ckABWFX9uLDuKeJLoOdfBm7RzllrzjrlSSGgiMsrrvh+9Q=="],
 
     "@steipete/sweet-cookie": ["@steipete/sweet-cookie@0.4.1", "", { "bin": { "sweet-cookie": "dist/cli.js" } }, "sha512-6cuWTGeblwzMw4/3uMzBEmgH1B+crCkJJlmTVu4vzbhG2NhAH8sMWv57fQ8JZY0nqW2ldM0/c2JM0UeQQFyJ3g=="],
 
@@ -152,7 +152,7 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+    "chalk": ["chalk@6.0.0", "", {}, "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -386,7 +386,7 @@
 
     "macos-version": ["macos-version@6.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-O2S8voA+pMfCHhBn/TIYDXzJ1qNHpPDU32oFxglKnVdJABiYYITt45oLkV9yhwA3E2FDwn3tQqUFrTsr1p3sBQ=="],
 
-    "markdansi": ["markdansi@0.3.2", "", { "dependencies": { "chalk": "^5.6.2", "decode-named-character-reference": "^1.3.0", "marked": "^18.0.5", "slice-ansi": "^9.0.0", "string-width": "^8.2.1", "strip-ansi": "^7.2.0", "supports-hyperlinks": "^4.5.0" }, "bin": { "markdansi": "dist/cli.js" } }, "sha512-ReXpi/vPwRb6WhXxMzKpzX/ty2CuulskHGQhVMbDcc6gQSr3X6YYMInnims6aaiO3xl0B6Usrzd3FzwlF3sCww=="],
+    "markdansi": ["markdansi@0.3.3", "", { "dependencies": { "chalk": "^6.0.0", "decode-named-character-reference": "^1.3.0", "marked": "^18.0.7", "slice-ansi": "^9.0.0", "string-width": "^8.2.2", "strip-ansi": "^7.2.0", "supports-hyperlinks": "^4.5.0" }, "bin": { "markdansi": "dist/cli.js" } }, "sha512-RPVzHLcC/R3q1+ZTj/yrGkOIGCGxIHq8/lg3O4B2EqDzwpfz7gibwwCmkFzB1cftvaU1/H2+5LTpOQzvkBuPFQ=="],
 
     "marked": ["marked@18.0.9", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w=="],
 
@@ -452,7 +452,7 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
-    "openai": ["openai@6.49.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg=="],
+    "openai": ["openai@7.8.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "undici": ">=5 <9", "ws": "^8.21.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "undici", "ws", "zod"] }, "sha512-/2g9JzdnXNcjX1W/UlSNu+OdSFDAaAVt0n9Onom0kPenH54o59G2WrX/xjTnr26UHNSh6hxcAf58doGYRme2rw=="],
 
     "osc-progress": ["osc-progress@0.3.2", "", {}, "sha512-ZKd6rgRqlnBpw/XwK+x9LwRbgQiJbxvOFD8F8wGLrEF9FxzWDbJQdvWLk6oFxhlLI1S43ECEGPDpI+J7Oi20YA=="],
 
@@ -548,7 +548,7 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
+    "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 


### PR DESCRIPTION
## Root cause

PR #116 ( Dependabot npm bump of `@steipete/oracle` 0.16.1 → 0.17.1, merged 2026-08-10) updated `package.json` only. The Dependabot npm ecosystem does not update `bun.lock`, so the root lockfile still pinned 0.16.1.

Since then every CI run that executes `bun install --frozen-lockfile` fails with:

```
error: lockfile had changes, but lockfile is frozen
```

This is why `Quality Checks (validate-skills)` and `Validate JSON Schemas` are red on main and on all open PRs (#117, #118, #119, #121).

## Fix

Regenerated `bun.lock` with `bun install` (only the oracle entries move 0.16.1 → 0.17.1). Verified `bun install --frozen-lockfile` now passes locally (`Checked 325 installs across 323 packages (no changes)`).

## Impact

Unblocks the entire merge queue: main turns green, and the four open PRs inherit the fix once rebased on the new main.