### PR TITLE
docs: add reply-format rules (labels, DONE block, no wordplay)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,45 @@ Read `CLAUDE.md` for the full repository context before making project changes.
 - Do not use jargon. If a technical term cannot be avoided, explain it in one short sentence.
 - This rule is the most important one in this file and in `CLAUDE.md`.
 
+## How to Show Me Your Work
+
+These rules apply to chat replies only — not to pull request descriptions or
+commit messages.
+
+### 1. Label every part of a reply
+
+Skip the labels only for quick one-line answers. Use these labels:
+
+- 🔍 **What I found** — what was discovered or checked
+- 🔧 **What I did** — changes that were made
+- ⚠️ **Problem** — something broken or blocked
+- ❓ **Question** — a question the assistant needs answered
+- 📝 **Note** — small side info (neither a finding nor a fix)
+- ➡️ **Next for you** — what the user needs to do, or "nothing"
+
+### 2. End finished work with a DONE block
+
+Whenever you finish building or fixing something, end the reply with exactly
+this block:
+
+```
+------------------------------------------
+✅ DONE
+What changed: <one or two simple sentences>
+Checks: <which checks ran and that they passed — or "none run">
+➡️ Next for you: <what the user needs to do, or "nothing">
+```
+
+### 3. No wordplay about places or things
+
+Never write riddle-style phrases like "it lives in the basement, not the
+garden" or "the rule is in the header, not the code". When pointing at
+something in this project, always name the real file or place (for example:
+"the `.github/workflows/quality-checks.yml` file"). No jokes and no nicknames
+for files or code. A small everyday comparison is allowed only when it truly
+helps explain a hard technical idea, and it must be explained in plain words
+right there.
+
 ## Oracle Shared Reviews
 
 - Use Oracle for a second opinion when stuck, when reviewing architecture, before risky refactors, or when validating a plan with another model.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,47 @@ prefer `preset: "chatgpt-pro-heavy"` or explicit `engine: "browser"`.
 
 ---
 
+## How to Show Me Your Work
+
+These rules apply to chat replies only — not to pull request descriptions or
+commit messages.
+
+### 1. Label every part of a reply
+
+Skip the labels only for quick one-line answers. Use these labels:
+
+- 🔍 **What I found** — what was discovered or checked
+- 🔧 **What I did** — changes that were made
+- ⚠️ **Problem** — something broken or blocked
+- ❓ **Question** — a question the assistant needs answered
+- 📝 **Note** — small side info (neither a finding nor a fix)
+- ➡️ **Next for you** — what the user needs to do, or "nothing"
+
+### 2. End finished work with a DONE block
+
+Whenever you finish building or fixing something, end the reply with exactly
+this block:
+
+```
+------------------------------------------
+✅ DONE
+What changed: <one or two simple sentences>
+Checks: <which checks ran and that they passed — or "none run">
+➡️ Next for you: <what the user needs to do, or "nothing">
+```
+
+### 3. No wordplay about places or things
+
+Never write riddle-style phrases like "it lives in the basement, not the
+garden" or "the rule is in the header, not the code". When pointing at
+something in this project, always name the real file or place (for example:
+"the `.github/workflows/quality-checks.yml` file"). No jokes and no nicknames
+for files or code. A small everyday comparison is allowed only when it truly
+helps explain a hard technical idea, and it must be explained in plain words
+right there.
+
+---
+
 ## SAP-Specific Infrastructure
 
 ### Marketplace System


### PR DESCRIPTION
## What changed

Added a new `## How to Show Me Your Work` section to both `AGENTS.md` and `CLAUDE.md` with identical text (29 content lines each, verified):

1. **Label every part of a reply** — 🔍 What I found, 🔧 What I did, ⚠️ Problem, ❓ Question, 📝 Note, ➡️ Next for you (labels skipped only for quick one-line answers).
2. **End finished work with a DONE block** — fixed template with What changed / Checks / Next for you.
3. **No wordplay about places or things** — always name the real file or place; no riddle-style phrases or nicknames.

Scope stated in the section: chat replies only — not pull request descriptions or commit messages.

### Placement

- `AGENTS.md`: right after "Most Important Rule: Plain Language".
- `CLAUDE.md`: right after the "Critical Directives" block (its plain-language rule is directive 1 inside that block; inserting a `##` section mid-block would break the heading structure).

The plan's example file `public/_headers` (from another repo) was swapped for a real file in this repo: `.github/workflows/quality-checks.yml`.

Docs-only change; no code or workflows touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for consistently formatting chat responses.
  * Introduced a standardized completion marker for finished work.
  * Clarified naming conventions for files, locations, and code references.
  * Specified that these guidelines apply to chat replies, not pull requests or commit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->